### PR TITLE
Fix env loading and mapping query

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,9 @@ from fastapi import FastAPI
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy import text
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 app = FastAPI()
 
@@ -16,5 +19,5 @@ async def root():
 async def get_properties():
     async with engine.connect() as conn:
         result = await conn.execute(text("SELECT * FROM properties"))
-        rows = result.fetchall()
-        return [dict(row._mapping) for row in rows]
+        rows = result.mappings().all()
+        return [dict(row) for row in rows]


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- avoid using private attributes when returning properties

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685a962ac234832a8c385e2deb955e1b