### PR TITLE
Fix listings page backend URL fallback

### DIFF
--- a/frontend/__tests__/lib/api-url-resolution.spec.tsx
+++ b/frontend/__tests__/lib/api-url-resolution.spec.tsx
@@ -1,6 +1,6 @@
 /**
  * Test API URL resolution logic across the frontend
- * Ensures consistent fallback chain: BACKEND_URL -> API_BASE -> API_URL -> localhost
+ * Ensures consistent fallback chain: BACKEND_URL -> API_BASE -> API_URL -> production default
  */
 
 describe('API URL Resolution', () => {
@@ -60,19 +60,18 @@ describe('API URL Resolution', () => {
     });
   });
 
-  describe('Inline URL resolution (simulating listings page pattern)', () => {
+  describe('resolveApiBase helper (used by listings + client fetchers)', () => {
+    const railwayDefault = 'https://propnexus-backend-production.up.railway.app';
+
     it('should resolve BACKEND_URL first', () => {
       process.env.NEXT_PUBLIC_BACKEND_URL = 'https://backend.example.com';
       process.env.NEXT_PUBLIC_API_BASE = 'https://base.example.com';
       process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com';
 
-      const backendUrl = 
-        process.env.NEXT_PUBLIC_BACKEND_URL || 
-        process.env.NEXT_PUBLIC_API_BASE || 
-        process.env.NEXT_PUBLIC_API_URL || 
-        'http://localhost:8000';
-
-      expect(backendUrl).toBe('https://backend.example.com');
+      jest.isolateModules(() => {
+        const { resolveApiBase } = require('@/lib/api');
+        expect(resolveApiBase()).toBe('https://backend.example.com');
+      });
     });
 
     it('should fallback to API_BASE when BACKEND_URL not set', () => {
@@ -80,13 +79,10 @@ describe('API URL Resolution', () => {
       process.env.NEXT_PUBLIC_API_BASE = 'https://base.example.com';
       process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com';
 
-      const backendUrl = 
-        process.env.NEXT_PUBLIC_BACKEND_URL || 
-        process.env.NEXT_PUBLIC_API_BASE || 
-        process.env.NEXT_PUBLIC_API_URL || 
-        'http://localhost:8000';
-
-      expect(backendUrl).toBe('https://base.example.com');
+      jest.isolateModules(() => {
+        const { resolveApiBase } = require('@/lib/api');
+        expect(resolveApiBase()).toBe('https://base.example.com');
+      });
     });
 
     it('should fallback to API_URL when only API_URL is set (Railway fix)', () => {
@@ -94,43 +90,32 @@ describe('API URL Resolution', () => {
       delete process.env.NEXT_PUBLIC_API_BASE;
       process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com';
 
-      const backendUrl = 
-        process.env.NEXT_PUBLIC_BACKEND_URL || 
-        process.env.NEXT_PUBLIC_API_BASE || 
-        process.env.NEXT_PUBLIC_API_URL || 
-        'http://localhost:8000';
-
-      expect(backendUrl).toBe('https://api.example.com');
+      jest.isolateModules(() => {
+        const { resolveApiBase } = require('@/lib/api');
+        expect(resolveApiBase()).toBe('https://api.example.com');
+      });
     });
 
-    it('should fallback to localhost when no env vars are set', () => {
+    it('should fallback to production default when no env vars are set', () => {
       delete process.env.NEXT_PUBLIC_BACKEND_URL;
       delete process.env.NEXT_PUBLIC_API_BASE;
       delete process.env.NEXT_PUBLIC_API_URL;
 
-      const backendUrl = 
-        process.env.NEXT_PUBLIC_BACKEND_URL || 
-        process.env.NEXT_PUBLIC_API_BASE || 
-        process.env.NEXT_PUBLIC_API_URL || 
-        'http://localhost:8000';
-
-      expect(backendUrl).toBe('http://localhost:8000');
+      jest.isolateModules(() => {
+        const { resolveApiBase } = require('@/lib/api');
+        expect(resolveApiBase()).toBe(railwayDefault);
+      });
     });
 
-    it('should not fallback to localhost when API_URL is set (the bug we fixed)', () => {
+    it('should strip trailing slashes', () => {
       delete process.env.NEXT_PUBLIC_BACKEND_URL;
-      delete process.env.NEXT_PUBLIC_API_BASE;
-      process.env.NEXT_PUBLIC_API_URL = 'https://production.railway.app';
+      process.env.NEXT_PUBLIC_API_BASE = 'https://base.example.com///';
+      delete process.env.NEXT_PUBLIC_API_URL;
 
-      const backendUrl = 
-        process.env.NEXT_PUBLIC_BACKEND_URL || 
-        process.env.NEXT_PUBLIC_API_BASE || 
-        process.env.NEXT_PUBLIC_API_URL || 
-        'http://localhost:8000';
-
-      // This is the fix: should NOT be localhost when API_URL is set
-      expect(backendUrl).not.toBe('http://localhost:8000');
-      expect(backendUrl).toBe('https://production.railway.app');
+      jest.isolateModules(() => {
+        const { resolveApiBase } = require('@/lib/api');
+        expect(resolveApiBase()).toBe('https://base.example.com');
+      });
     });
   });
 });

--- a/frontend/app/listings/page.tsx
+++ b/frontend/app/listings/page.tsx
@@ -10,6 +10,7 @@ import { FiSearch, FiSliders, FiMapPin, FiMap, FiGrid, FiX } from 'react-icons/f
 import { LuPoundSterling, LuBedDouble, LuBath } from 'react-icons/lu';
 
 import PropertyCard from '@/components/PropertyCard';
+import { resolveApiBase } from '@/lib/api';
 
 /* ---------------- Helper Functions ---------------- */
 /**
@@ -284,9 +285,8 @@ function ListingsInner() {
       setLoading(true);
       
       try {
-        // Resolve backend URL using standard env var priority (consistent with lib/api.ts and PropertyCard.tsx)
-        // Order: NEXT_PUBLIC_BACKEND_URL -> NEXT_PUBLIC_API_BASE -> NEXT_PUBLIC_API_URL -> localhost fallback
-        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+        // Resolve backend URL using shared helper so builds without env vars still hit production backend
+        const backendUrl = resolveApiBase();
         
         // Build query params
         const params = new URLSearchParams();

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -9,6 +9,15 @@ export const API_BASE =
   process.env.NEXT_PUBLIC_API_URL ||
   'https://propnexus-backend-production.up.railway.app';
 
+/**
+ * Resolve the backend base URL using the shared env var priority.
+ * Always falls back to the production Railway backend instead of localhost
+ * to avoid silent failures when env vars are missing in production builds.
+ */
+export function resolveApiBase(): string {
+  return (API_BASE || 'https://propnexus-backend-production.up.railway.app').replace(/\/+$/, '');
+}
+
 /* ---------------------------------------------------
    Generic Helpers (new + legacy compatibility)
 --------------------------------------------------- */


### PR DESCRIPTION
## Summary
- add a shared resolveApiBase helper that keeps env resolution consistent and defaults to the production backend
- use the shared resolver on the listings page to avoid falling back to localhost when env vars are missing
- update the API URL resolution tests to cover the helper and trailing-slash handling

## Testing
- npm test -- __tests__/lib/api-url-resolution.spec.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923766a6770832ab631f97231250d9c)