### PR TITLE
Launch readiness followups: pagination, normalization, checklist

### DIFF
--- a/backend/routes/import_routes.py
+++ b/backend/routes/import_routes.py
@@ -53,6 +53,112 @@ def _clean_row(p: Dict[str, Any], now_iso: str) -> Dict[str, Any]:
     row["last_seen_at"] = now_iso
     row.pop("ai_ready", None)
 
+    def _norm_url(v: Any) -> Any:
+        if not isinstance(v, str):
+            return v
+        s = v.strip()
+        if s.startswith("//"):
+            return f"https:{s}"
+        return s
+
+    def _coerce_int(v: Any) -> int | None:
+        if v is None:
+            return None
+        if isinstance(v, bool):
+            return None
+        if isinstance(v, int):
+            return v
+        if isinstance(v, float):
+            return int(v)
+        if isinstance(v, str):
+            digits = "".join(ch for ch in v if ch.isdigit())
+            try:
+                return int(digits) if digits else None
+            except Exception:
+                return None
+        return None
+
+    def _coerce_float(v: Any) -> float | None:
+        if v is None:
+            return None
+        if isinstance(v, bool):
+            return None
+        if isinstance(v, (int, float)):
+            return float(v)
+        if isinstance(v, str):
+            try:
+                return float(v.strip())
+            except Exception:
+                return None
+        return None
+
+    # Optional hydration from `data.raw` when top-level fields are missing.
+    data_obj = row.get("data")
+    raw_obj: Dict[str, Any] = {}
+    if isinstance(data_obj, dict):
+        if isinstance(data_obj.get("raw"), dict):
+            raw_obj = data_obj.get("raw")  # type: ignore[assignment]
+        else:
+            raw_obj = data_obj
+
+    def _pick_raw(keys: List[str]) -> Any:
+        for k in keys:
+            v = raw_obj.get(k)
+            if v not in (None, "", [], {}):
+                return v
+        return None
+
+    # Map scraper field names into DB schema.
+    if not row.get("imageurl"):
+        row["imageurl"] = (
+            row.get("image_url")
+            or row.get("imageUrl")
+            or _pick_raw(["imageurl", "image_url", "imageUrl", "image", "imageUrlLarge"])
+        )
+    row["imageurl"] = _norm_url(row.get("imageurl"))
+    row.pop("image_url", None)
+    row.pop("imageUrl", None)
+
+    if isinstance(row.get("image_urls"), list):
+        row["image_urls"] = [
+            _norm_url(u) for u in row.get("image_urls") if isinstance(u, str) and u.strip()
+        ]
+    elif not row.get("image_urls"):
+        raw_imgs = _pick_raw(["image_urls", "imageUrls", "images"])
+        if isinstance(raw_imgs, list):
+            row["image_urls"] = [_norm_url(u) for u in raw_imgs if isinstance(u, str) and u.strip()]
+
+    if not row.get("location"):
+        row["location"] = _pick_raw(["location", "displayAddress", "display_address"])
+    if not row.get("address"):
+        row["address"] = _pick_raw(["address", "displayAddress", "display_address", "location"])
+
+    if row.get("price") in (None, 0, 0.0, ""):
+        raw_price = _pick_raw(["price", "displayPrice", "display_price"])
+        row["price"] = _coerce_int(raw_price) if raw_price is not None else row.get("price")
+
+    if row.get("bedrooms") in (None, 0, ""):
+        raw_beds = _pick_raw(["bedrooms", "beds", "numBedrooms", "numberOfBedrooms"])
+        beds = _coerce_int(raw_beds)
+        if beds is not None and beds > 0:
+            row["bedrooms"] = beds
+
+    if row.get("bathrooms") in (None, 0, ""):
+        raw_baths = _pick_raw(["bathrooms", "baths", "numBathrooms", "numberOfBathrooms"])
+        baths = _coerce_int(raw_baths)
+        if baths is not None and baths > 0:
+            row["bathrooms"] = baths
+
+    if row.get("latitude") in (None, 0, 0.0, ""):
+        lat = _coerce_float(_pick_raw(["latitude", "lat"]))
+        if lat is not None and lat != 0.0:
+            row["latitude"] = lat
+
+    if row.get("longitude") in (None, 0, 0.0, ""):
+        lng = _coerce_float(_pick_raw(["longitude", "lng", "lon"]))
+        if lng is not None and lng != 0.0:
+            row["longitude"] = lng
+
     # DB schema uses `url` (see supabase/schema.sql). Scrapers/normalizers may
     # emit `listing_url` or `raw_url`; map those into `url` and drop the alias
     # to avoid PostgREST "column does not exist" failures.

--- a/backend/scraper/rightmove_scraper.py
+++ b/backend/scraper/rightmove_scraper.py
@@ -563,7 +563,8 @@ def _build_search_url(location: str, page: int = 0) -> str:
             "propertyTypes=&mustHave=&dontShow=houseShare%2Cretirement%2CsharedOwnership",
             "furnishTypes=&keywords=",
             "includeSSTC=false",
-            f"index={page * 24}",
+            # Rightmove HTML pagination uses paginationIndex=0,1,2... for listings pages.
+            f"paginationIndex={int(page)}",
         ]
         return f"{base}?{'&'.join(params)}"
 
@@ -577,7 +578,9 @@ def _build_search_url(location: str, page: int = 0) -> str:
         "sortType=2",
         "propertyTypes=&mustHave=&dontShow=houseShare%2Cretirement%2CsharedOwnership",
         "furnishTypes=&keywords=",
-        f"index={page * 24}",  # Rightmove step size often 24
+        # Prefer paginationIndex for the HTML listing pages.
+        # Keep index-based pagination for free-text searches, which can still accept index offsets.
+        f"paginationIndex={int(page)}" if loc_key in _LOCATION_IDENTIFIER else f"index={page * 24}",
     ]
     return f"{base}?{'&'.join(params)}"
 

--- a/backend/tests/test_import_normalization.py
+++ b/backend/tests/test_import_normalization.py
@@ -1,0 +1,60 @@
+from backend.routes.import_routes import _clean_row
+
+
+def test_clean_row_hydrates_from_data_raw_and_normalizes_urls():
+    now_iso = "2026-01-01T00:00:00Z"
+    raw = {
+        "location": "London",
+        "price": "£350,000",
+        "bedrooms": 2,
+        "bathrooms": 1,
+        "latitude": 51.5,
+        "longitude": -0.12,
+        "image_url": "//images.example.com/a.jpg",
+        "image_urls": ["//images.example.com/a.jpg", "https://images.example.com/b.jpg"],
+    }
+
+    p = {
+        "title": "Test",
+        "source": "zoopla",
+        "external_id": "123",
+        "data": {"raw": raw},
+        # Intentionally missing top-level fields that the UI uses.
+        "location": None,
+        "address": None,
+        "price": None,
+        "bedrooms": 0,
+        "bathrooms": 0,
+        "latitude": 0.0,
+        "longitude": 0.0,
+        "imageurl": None,
+        "image_urls": ["//images.example.com/c.jpg"],
+    }
+
+    row = _clean_row(p, now_iso)
+
+    assert row["location"] == "London"
+    assert row["address"] == "London"
+    assert row["price"] == 350000
+    assert row["bedrooms"] == 2
+    assert row["bathrooms"] == 1
+    assert row["latitude"] == 51.5
+    assert row["longitude"] == -0.12
+
+    assert row["imageurl"] == "https://images.example.com/a.jpg"
+    assert row["image_urls"][0] == "https://images.example.com/c.jpg"
+
+
+def test_clean_row_maps_image_url_field_name_to_imageurl():
+    now_iso = "2026-01-01T00:00:00Z"
+    p = {
+        "title": "Test",
+        "source": "rightmove",
+        "external_id": "123",
+        "image_url": "//cdn.example.com/x.jpg",
+    }
+
+    row = _clean_row(p, now_iso)
+
+    assert "image_url" not in row
+    assert row["imageurl"] == "https://cdn.example.com/x.jpg"

--- a/backend/tests/test_scraper_improvements.py
+++ b/backend/tests/test_scraper_improvements.py
@@ -497,13 +497,22 @@ def test_zoopla_search_url_slugified():
 
 
 def test_rightmove_search_url_includes_index_page0():
-    """Regression: Rightmove HTML URL must include index=0 for page 0."""
+    """Regression: Rightmove HTML URL must include paginationIndex=0 for page 0."""
     from backend.scraper.rightmove_scraper import _build_search_url
 
     url0 = _build_search_url("London", page=0)
-    assert "index=0" in url0
+    assert "paginationIndex=0" in url0
     assert "locationIdentifier=REGION%5E87490" in url0
     assert "channel=BUY" not in url0
+
+
+def test_rightmove_search_url_increments_pagination_index():
+    """Regression: page=1 must request paginationIndex=1 (not index=24)."""
+    from backend.scraper.rightmove_scraper import _build_search_url
+
+    url1 = _build_search_url("London", page=1)
+    assert "paginationIndex=1" in url1
+    assert "index=24" not in url1
 
 
 def test_onthemarket_search_url_lowercases_location():
@@ -524,7 +533,7 @@ def test_rightmove_caret_retry_targets_include_unescaped_first():
     """Regression: caret-unescape retry should exist for REGION%5E URLs."""
     from backend.scraper.rightmove_scraper import _rightmove_caret_url_variants
 
-    url = "https://www.rightmove.co.uk/property-for-sale/find.html?locationIdentifier=REGION%5E87490&index=0"
+    url = "https://www.rightmove.co.uk/property-for-sale/find.html?locationIdentifier=REGION%5E87490&paginationIndex=0"
     variants = _rightmove_caret_url_variants(url)
     assert variants[0].count("REGION^") == 1
     assert any("REGION%5E87490" in v for v in variants)

--- a/docs/launch_checklist.md
+++ b/docs/launch_checklist.md
@@ -1,118 +1,206 @@
-# Launch Readiness Checklist
+# Go-Live PASS/FAIL Checklist
 
-Use this checklist before merging `launch-readiness` back into `main` and before each production deploy.
+This is a strict go-live checklist. Every step has a command, a PASS condition, and what to do if it FAILs.
 
-## 1) Code + CI
-- [ ] All changes are on a non-main branch (e.g. `launch-readiness`)
-- [ ] Backend tests: `pytest -q` is green
-- [ ] Frontend tests (if used): `cd frontend && npm test` is green
-- [ ] Playwright e2e (if used): `cd frontend && npx playwright test` is green
+## 0) Prereqs (one-time)
 
-## 2) Critical Integrations
+### Load env (Codespaces/devcontainer)
 
-### Stripe
-- [ ] `STRIPE_SECRET_KEY` configured (prod key in prod)
-- [ ] `STRIPE_WEBHOOK_SECRET` configured (prod webhook secret in prod)
-- [ ] Webhook endpoint returns `200` for valid events
-- [ ] Verified at least one real event in Stripe dashboard after deploy
-
-### Supabase
-- [ ] `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` configured
-- [ ] RLS policies and required tables exist
-- [ ] Schema is up-to-date with `supabase/schema.sql` (or any migration process you use)
-
-## 3) Scrapers
-
-### Global scraper settings
-- [ ] `SCRAPER_MODE` is set correctly in production (recommended: `scraperapi` or `smart`)
-- [ ] `SCRAPERAPI_KEY` present in production if `SCRAPER_MODE` is `scraperapi`/`smart`
-- [ ] `PLAYWRIGHT_ENABLE=false` in production unless explicitly needed
-
-### Rightmove
-- [ ] Rightmove import returns non-zero items for a known-good location (or logs explain why 0)
-- [ ] Minimal ScraperAPI URL retry works when the "place not found" variant appears
-- [ ] `backend/tests/test_rightmove_minimal_url_retry.py` passes
-
-### Other sources
-- [ ] Zoopla import works for a known location
-- [ ] OnTheMarket import works for a known location
-- [ ] SpareRoom import works for a known location
-
-## 4) Admin + Debug Endpoints
-- [ ] `IMPORT_ADMIN_TOKEN` configured (recommended in prod)
-- [ ] Import endpoints require `x-admin-token` when `IMPORT_ADMIN_TOKEN` is set
-- [ ] Debug scrape probe endpoint is protected in production
-
-### Quick curl checks (local or deployed)
-
-Set a base URL first:
+Command:
 
 ```bash
-export BASE_URL="http://localhost:8000"
-# or your Railway URL
+source scripts/codespaces_env.sh
 ```
 
-Then hit the key routes:
+PASS:
+- Prints `BACKEND_URL=...`
+- Prints `ADMIN_TOKEN=<set>`
+
+FAIL → Next action:
+- Create `.env.codespaces` or `.env.local` with `BACKEND_URL=...` and `ADMIN_TOKEN=...`, or create a local `.admin_token` file.
+
+## 1) Environment configured
+
+PASS:
+- Railway backend has `IMPORT_ADMIN_TOKEN`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and (if using ScraperAPI) `SCRAPERAPI_KEY`.
+- Vercel frontend has `NEXT_PUBLIC_API_BASE` pointing at Railway backend.
+
+FAIL → Next action:
+- Set missing env vars in Railway/Vercel and redeploy.
+
+## 2) Backend health
+
+Command:
 
 ```bash
-# Health
-curl -sS "$BASE_URL/health"
-
-# Imports (token required only if IMPORT_ADMIN_TOKEN is set)
-
-# Expect 401 when IMPORT_ADMIN_TOKEN is set and header is missing:
-curl -i -sS -X POST "$BASE_URL/import/rightmove" -H 'content-type: application/json' \
-	-d '{"location":"London"}'
-
-curl -sS -X POST "$BASE_URL/import/rightmove" -H 'content-type: application/json' \
-	-H "x-admin-token: $IMPORT_ADMIN_TOKEN" \
-	-d '{"location":"London"}'
-
-curl -sS -X POST "$BASE_URL/import/zoopla" -H 'content-type: application/json' \
-	-H "x-admin-token: $IMPORT_ADMIN_TOKEN" \
-	-d '{"location":"London"}'
-
-curl -sS -X POST "$BASE_URL/import/onthemarket" -H 'content-type: application/json' \
-	-H "x-admin-token: $IMPORT_ADMIN_TOKEN" \
-	-d '{"location":"London"}'
-
-curl -sS -X POST "$BASE_URL/import/spareroom" -H 'content-type: application/json' \
-	-H "x-admin-token: $IMPORT_ADMIN_TOKEN" \
-	-d '{"location":"London"}'
-
-# All-sources import
-curl -sS -X POST "$BASE_URL/import/all?req=London" -H "x-admin-token: $IMPORT_ADMIN_TOKEN"
-
-# Debug scrape probe (protected by IMPORT_ADMIN_TOKEN when configured)
-curl -sS "$BASE_URL/debug/scrape-probe?location=London&sources=rightmove,zoopla" \
-	-H "x-admin-token: $IMPORT_ADMIN_TOKEN"
-
-# AI routes
-curl -sS -X POST "$BASE_URL/ai/summary" -H 'content-type: application/json' \
-	-d '{"title":"2 bed flat","location":"London","price":350000,"yield":5.2,"roi":9.1,"description":"Bright, close to station"}'
-
-# GPT scoring routes
-curl -sS -X POST "$BASE_URL/gpt/score" -H 'content-type: application/json' -d '{}'
+curl -sS -o /dev/null -w "%{http_code}\n" "$BACKEND_URL/health"
 ```
 
-## 5) Runtime Smoke Test
-- [ ] Backend boots: `uvicorn backend.main:app` (or Railway) and `/health` returns `200`
-- [ ] Frontend boots (Vercel) and auth flow works end-to-end
-- [ ] Can import properties and see them in UI
-- [ ] AI endpoints return expected JSON structure (or are disabled via flags)
+PASS:
+- Output is `200`
 
-### UI smoke steps (5-10 minutes)
-- [ ] Create account / sign in
-- [ ] Import properties (Rightmove + at least one other source)
-- [ ] Open a listing detail page and confirm key fields render
-- [ ] Trigger AI summary/strategies and confirm consistent responses (or a clean 503 when AI is not configured)
+FAIL → Next action:
+- Check Railway logs for startup errors and confirm env vars are present.
 
-## 6) Stripe Webhook Verification (production)
-- [ ] Confirm webhook endpoint URL in Stripe points to `$BASE_URL/stripe/webhook`
-- [ ] From Stripe dashboard: send a test event (e.g. `checkout.session.completed`) and verify 2xx response
-- [ ] Confirm at least one real event appears after a real checkout
-- [ ] If failures occur: check Railway logs and Stripe “Webhook Attempts” error details
+## 3) Admin token gating
 
-## 6) Observability
-- [ ] Error reporting (Sentry) configured if enabled
-- [ ] Key logs/metrics present for scraping/import failures (zero-results warnings, blocking detection)
+Command (missing token):
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "$BACKEND_URL/import/all?req=London"
+```
+
+PASS:
+- Output is `401` when `IMPORT_ADMIN_TOKEN` is set in production
+
+FAIL → Next action:
+- Confirm `IMPORT_ADMIN_TOKEN` is set on Railway and the backend is redeployed.
+
+Command (with token):
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "$BACKEND_URL/import/all?req=London" \
+	-H "x-admin-token: $ADMIN_TOKEN"
+```
+
+PASS:
+- Output is `200`
+
+FAIL → Next action:
+- Verify `$ADMIN_TOKEN` matches Railway `IMPORT_ADMIN_TOKEN` exactly (no whitespace/newlines).
+
+## 4) Imports (expect non-zero for Zoopla/OTM/SpareRoom)
+
+NOTE:
+- Rightmove may be `0` until the ScraperAPI pool issue is resolved.
+- Zoopla / OnTheMarket / SpareRoom should be `> 0` for at least one known-good location.
+
+### Zoopla
+
+Command:
+
+```bash
+curl -sS -X POST "$BACKEND_URL/import/zoopla" \
+	-H "x-admin-token: $ADMIN_TOKEN" \
+	-H "content-type: application/json" \
+	-d '{"location":"London"}'
+```
+
+PASS:
+- Response JSON contains `"count"` and it is `> 0`
+
+FAIL → Next action:
+- Run the probe endpoint (Step 6) and check for blocking/timeouts.
+
+### OnTheMarket
+
+Command:
+
+```bash
+curl -sS -X POST "$BACKEND_URL/import/onthemarket" \
+	-H "x-admin-token: $ADMIN_TOKEN" \
+	-H "content-type: application/json" \
+	-d '{"location":"London"}'
+```
+
+PASS:
+- Response JSON contains `"count"` and it is `> 0`
+
+FAIL → Next action:
+- Run the probe endpoint (Step 6) and check for blocking/timeouts.
+
+### SpareRoom
+
+Command:
+
+```bash
+curl -sS -X POST "$BACKEND_URL/import/spareroom" \
+	-H "x-admin-token: $ADMIN_TOKEN" \
+	-H "content-type: application/json" \
+	-d '{"location":"Birmingham"}'
+```
+
+PASS:
+- Response JSON contains `"count"` and it is `> 0`
+
+FAIL → Next action:
+- Run the probe endpoint (Step 6) and check for blocking/timeouts.
+
+### Rightmove (known issue)
+
+Command:
+
+```bash
+curl -sS -X POST "$BACKEND_URL/import/rightmove" \
+	-H "x-admin-token: $ADMIN_TOKEN" \
+	-H "content-type: application/json" \
+	-d '{"location":"London"}'
+```
+
+PASS:
+- Response is `200` and includes `"count"` (may be `0` currently)
+
+FAIL → Next action:
+- Confirm `SCRAPER_MODE` and `SCRAPERAPI_KEY` are set; run Step 6 probe.
+
+## 5) Properties endpoint returns count > 0
+
+Command:
+
+```bash
+curl -sS "$BACKEND_URL/properties?limit=50" \
+	| /workspaces/propnexus-platform/.venv/bin/python - <<'PY'
+import json,sys
+data=json.load(sys.stdin)
+print(len(data) if isinstance(data,list) else 0)
+sys.exit(0 if isinstance(data,list) and len(data)>0 else 1)
+PY
+```
+
+PASS:
+- Command prints a number `> 0` and exits `0`
+
+FAIL → Next action:
+- Re-run Zoopla/OTM/SpareRoom imports; check Supabase table `properties` and Railway logs.
+
+## 6) Debug scrape probe (diagnostics)
+
+Command:
+
+```bash
+curl -sS "$BACKEND_URL/debug/scrape-probe?location=London&sources=zoopla,onthemarket,spareroom" \
+	-H "x-admin-token: $ADMIN_TOKEN"
+```
+
+PASS:
+- Response JSON has `"ok": true`
+- Each requested source has `classification` of `parsed` (or `fetched_no_results` with an obvious explanation)
+
+FAIL → Next action:
+- If `blocked`: enable/verify ScraperAPI settings.
+- If `timeout`: increase timeouts or reduce sources.
+
+## 7) Frontend rendering (images + cards)
+
+PASS:
+- Listings page shows property cards from Zoopla/OTM/SpareRoom.
+- Card images load (no broken `//...` URLs).
+
+FAIL → Next action:
+- Verify Step 5 returns items and that `imageurl`/`image_urls` are populated.
+
+## 8) Stripe webhooks (production)
+
+PASS:
+- Stripe dashboard test event to `$BACKEND_URL/stripe/webhook` returns 2xx.
+- At least one real event shows after a real checkout.
+
+FAIL → Next action:
+- Check Railway logs and Stripe “Webhook Attempts”. Verify `STRIPE_WEBHOOK_SECRET`.
+
+## 9) Rollback / mitigation
+
+If go-live checks fail:
+- Roll back Railway deploy to the previous successful release.
+- Disable scraping features by setting `SCRAPER_MODE=direct` (temporary) and communicating limitations.
+- If Rightmove is the only failure, proceed with Zoopla/OTM/SpareRoom while ScraperAPI investigates.

--- a/scripts/codespaces_env.sh
+++ b/scripts/codespaces_env.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   source scripts/codespaces_env.sh [optional-env-file]
+#
+# Loads env vars commonly needed for curl-based verification in Codespaces/devcontainers.
+# - Does NOT print secrets.
+# - If an env file is provided, it will be sourced.
+# - Otherwise, tries .env.codespaces then .env.local then .env (if present).
+
+pick_env_file() {
+  local candidate
+  for candidate in "${1:-}" .env.codespaces .env.local .env; do
+    if [[ -n "$candidate" && -f "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+ENV_FILE=""
+if ENV_FILE="$(pick_env_file "${1:-}")"; then
+  # shellcheck disable=SC1090
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+# Convenience: allow storing admin token in a local file (ignored by git).
+if [[ -z "${ADMIN_TOKEN:-}" && -f .admin_token ]]; then
+  ADMIN_TOKEN="$(tr -d '\n' < .admin_token)"
+  export ADMIN_TOKEN
+fi
+
+# Defaults (safe): allow BACKEND_URL to be overridden.
+if [[ -z "${BACKEND_URL:-}" ]]; then
+  export BACKEND_URL="http://localhost:8000"
+fi
+
+# Summary (no secrets)
+echo "[codespaces_env] loaded: ${ENV_FILE:-<none>}"
+echo "[codespaces_env] BACKEND_URL=${BACKEND_URL}"
+echo "[codespaces_env] ADMIN_TOKEN=${ADMIN_TOKEN:+<set>}"


### PR DESCRIPTION
Follow-up launch readiness hardening:

- Fix Rightmove HTML pagination param mismatch (use paginationIndex for REGION/locationIdentifier flows).
- Normalize imported property rows so listings render reliably even if Rightmove is 0:
  - Map image_url->imageurl
  - Normalize protocol-relative URLs (// -> https:)
  - Hydrate key fields from data.raw when top-level values are missing
- Rewrite docs/launch_checklist.md into a strict PASS/FAIL go-live checklist with explicit curl commands and success criteria.
- Add scripts/codespaces_env.sh helper to load BACKEND_URL/ADMIN_TOKEN safely (no secrets printed).

Tests:
- /workspaces/propnexus-platform/.venv/bin/python -m pytest -q