### PR TITLE
CI: stop 'workflow file issue' failures (remove secrets from job if)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -8,11 +8,19 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ secrets.RAILWAY_TOKEN != '' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Secrets sanity check
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "ℹ️ RAILWAY_TOKEN not configured – skipping deploy (soft pass)."
+            exit 0
+          fi
 
       - name: Install Railway CLI
         run: |

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -9,13 +9,23 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_PROJECT_ID != '' && secrets.VERCEL_ORG_ID != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
       - run: npm i -g vercel@latest
+
+      - name: Secrets sanity check
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "ℹ️ Vercel secrets not configured – skipping deploy (soft pass)."
+            exit 0
+          fi
 
       - name: Vercel pull (prod)
         env:

--- a/.github/workflows/release-stripe-ci.yml
+++ b/.github/workflows/release-stripe-ci.yml
@@ -16,7 +16,6 @@ jobs:
   stripe-smoke:
     name: Stripe & Pricing Smoke
     runs-on: ubuntu-latest
-    if: ${{ secrets.STRIPE_SECRET_KEY != '' }}
 
     env:
       # Provide these via GitHub “Repository variables / secrets”

--- a/.github/workflows/scraper-go-live.yml
+++ b/.github/workflows/scraper-go-live.yml
@@ -22,7 +22,6 @@ on:
 jobs:
   scraper-go-live:
     runs-on: ubuntu-latest
-    if: ${{ secrets.API_BASE != '' && secrets.OFF_MARKET_ADMIN_TOKEN != '' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/scraper-monitor.yml
+++ b/.github/workflows/scraper-monitor.yml
@@ -10,15 +10,29 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: ${{ secrets.NEXT_PUBLIC_BACKEND_URL != '' || secrets.API_BASE != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Secrets sanity check
+        env:
+          API_BASE: ${{ secrets.API_BASE }}
+          NEXT_PUBLIC_BACKEND_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
+        run: |
+          if [ -z "$API_BASE" ] && [ -z "$NEXT_PUBLIC_BACKEND_URL" ]; then
+            echo "ℹ️ API_BASE / NEXT_PUBLIC_BACKEND_URL not configured – skipping monitor run (soft pass)."
+            exit 0
+          fi
+
       - name: Health check
         env:
-          BACKEND_BASE: ${{ secrets.API_BASE != '' && secrets.API_BASE || secrets.NEXT_PUBLIC_BACKEND_URL }}
+          API_BASE: ${{ secrets.API_BASE }}
+          NEXT_PUBLIC_BACKEND_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
         run: |
+          BACKEND_BASE="$API_BASE"
+          if [ -z "$BACKEND_BASE" ]; then
+            BACKEND_BASE="$NEXT_PUBLIC_BACKEND_URL"
+          fi
           if [ -z "${BACKEND_BASE}" ]; then
             echo "⚠️ BACKEND_BASE not configured – skipping monitor run (soft pass)."
             exit 0
@@ -31,9 +45,14 @@ jobs:
 
       - name: Test import with Ilford
         env:
-          BACKEND_BASE: ${{ secrets.API_BASE != '' && secrets.API_BASE || secrets.NEXT_PUBLIC_BACKEND_URL }}
+          API_BASE: ${{ secrets.API_BASE }}
+          NEXT_PUBLIC_BACKEND_URL: ${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
           OFF_MARKET_ADMIN_TOKEN: ${{ secrets.OFF_MARKET_ADMIN_TOKEN }}
         run: |
+          BACKEND_BASE="$API_BASE"
+          if [ -z "$BACKEND_BASE" ]; then
+            BACKEND_BASE="$NEXT_PUBLIC_BACKEND_URL"
+          fi
           if [ -z "${BACKEND_BASE}" ]; then
             echo "⚠️ BACKEND_BASE not configured – skipping import test (soft pass)."
             exit 0


### PR DESCRIPTION
Several workflows were failing instantly on main pushes with a “workflow file issue” and produced 0 jobs.

Root cause
- These workflows used job-level `if:` expressions that referenced the `secrets.*` context. GitHub Actions can reject workflows that reference secrets in job-level conditionals, resulting in a run with 0 jobs.

Fix
- Remove job-level `if:` conditions that use secrets.
- Add a first-step “Secrets sanity check” that exits 0 (soft pass) when secrets are missing.
- Simplify `scraper-monitor.yml` to avoid complex secret expressions in `env:` and compute the base URL in bash.

Files
- .github/workflows/deploy-frontend.yml
- .github/workflows/deploy-backend.yml
- .github/workflows/release-stripe-ci.yml
- .github/workflows/scraper-go-live.yml
- .github/workflows/scraper-monitor.yml
