### PR TITLE
Fix GPT score inputs + force backfill

### DIFF
--- a/backend/routes/gpt_routes.py
+++ b/backend/routes/gpt_routes.py
@@ -3,6 +3,8 @@ import os
 from fastapi import APIRouter, HTTPException
 from openai import OpenAI
 
+from backend.utils.deal_scoring import compute_deal_score
+
 router = APIRouter(prefix="/gpt", tags=["GPT AI"])
 
 # Lazy client initialization to avoid import-time errors
@@ -128,63 +130,11 @@ async def ai_score(data: dict):
     Input: property data dict
     Returns: {"ok": true, "score": 78, "categories": {...}, "version": "v1.0"}
     """
-    # Extract relevant metrics with defaults
-    yield_pct = data.get("yield_percent") or data.get("rental_yield_percent") or 0
-    roi_pct = data.get("roi_percent") or 0
-    price = data.get("price") or 0
-    rent = data.get("rent") or data.get("avg_rent") or 0
+    score, breakdown = compute_deal_score(data)
+    categories = breakdown.get("categories") or {}
+    version = breakdown.get("version") or "v1.0"
 
-    # Use explicit None checks to preserve 0 values
-    crime = data.get("crime_index")
-    crime = 50 if crime is None else float(crime)
-
-    schools = data.get("schools_rating")
-    schools = 3.0 if schools is None else float(schools)
-
-    # Calculate price-to-rent ratio (lower is better)
-    price_to_rent_ratio = (price / (rent * 12)) if (rent and price) else 0
-
-    # Category scores (out of max points each)
-    # Yield: 0-20 points (5%+ yield = 20pts, linear)
-    yield_score = min(20, (yield_pct / 5.0) * 20) if yield_pct > 0 else 0
-
-    # ROI: 0-20 points (10%+ ROI = 20pts, linear)
-    roi_score = min(20, (roi_pct / 10.0) * 20) if roi_pct > 0 else 0
-
-    # Price-to-rent: 0-15 points (ratio < 15 = 15pts, inverse linear)
-    ptr_score = 0
-    if price_to_rent_ratio > 0:
-        ptr_score = max(0, 15 - price_to_rent_ratio) if price_to_rent_ratio < 15 else 0
-        ptr_score = min(15, ptr_score)
-
-    # Area demand (proxy): 0-15 points (mock based on rent levels)
-    area_score = min(15, (rent / 1500.0) * 15) if rent > 0 else 0
-
-    # Crime index inverse: 0-15 points (crime 0-100, inverted: 100-crime gives 0-100, scale to 15)
-    crime_score = ((100 - crime) / 100.0) * 15
-
-    # Schools access: 0-15 points (rating 0-5, scale to 15)
-    schools_score = (schools / 5.0) * 15
-
-    # Total score
-    total = yield_score + roi_score + ptr_score + area_score + crime_score + schools_score
-    total = min(100, max(0, total))
-
-    categories = {
-        "yield": round(yield_score, 1),
-        "roi": round(roi_score, 1),
-        "price_to_rent": round(ptr_score, 1),
-        "area_demand": round(area_score, 1),
-        "crime_index_inverse": round(crime_score, 1),
-        "schools_access": round(schools_score, 1),
-    }
-
-    return {
-        "ok": True,
-        "score": round(total, 1),
-        "categories": categories,
-        "version": "v1.0",
-    }
+    return {"ok": True, "score": score, "categories": categories, "version": version}
 
 
 @router.post("/score/explain")

--- a/backend/routes/properties_routes.py
+++ b/backend/routes/properties_routes.py
@@ -692,6 +692,7 @@ def get_property(property_id: str, response: Response):
 @router.post("/properties/admin/backfill-scores")
 def backfill_property_scores(
     limit: int = Query(default=200, ge=1, le=500),
+    force: bool = Query(default=False),
     x_admin_token: str | None = Header(None),
 ):
     """Backfill score for legacy rows (score is NULL/0).
@@ -715,6 +716,7 @@ def backfill_property_scores(
             "crime_index",
             "schools_rating",
             "score",
+            "score_updated_at",
         ]
 
         def _missing_col_from_api_error(err: APIError) -> str | None:
@@ -750,32 +752,48 @@ def backfill_property_scores(
                 status_code=500, detail="Backfill failed: could not find a compatible column set"
             )
 
-        res_null = _select_with_existing_cols(
-            lambda select_cols: sb.table("properties")
-            .select(select_cols)
-            .is_("score", "null")
-            .limit(int(limit))
-        )
-        null_rows = res_null.data or []
-        if not isinstance(null_rows, list):
-            null_rows = []
+        if force:
+            res_all = _select_with_existing_cols(
+                lambda select_cols: (
+                    _safe_order(
+                        sb.table("properties").select(select_cols).limit(int(limit)),
+                        "score_updated_at",
+                        desc=False,
+                    )
+                    if "score_updated_at" in cols
+                    else sb.table("properties").select(select_cols).limit(int(limit))
+                )
+            )
+            rows = res_all.data or []
+            if not isinstance(rows, list):
+                rows = []
+        else:
+            res_null = _select_with_existing_cols(
+                lambda select_cols: sb.table("properties")
+                .select(select_cols)
+                .is_("score", "null")
+                .limit(int(limit))
+            )
+            null_rows = res_null.data or []
+            if not isinstance(null_rows, list):
+                null_rows = []
 
-        res_zero = _select_with_existing_cols(
-            lambda select_cols: sb.table("properties")
-            .select(select_cols)
-            .lte("score", 0)
-            .limit(int(limit))
-        )
-        zero_rows = res_zero.data or []
-        if not isinstance(zero_rows, list):
-            zero_rows = []
+            res_zero = _select_with_existing_cols(
+                lambda select_cols: sb.table("properties")
+                .select(select_cols)
+                .lte("score", 0)
+                .limit(int(limit))
+            )
+            zero_rows = res_zero.data or []
+            if not isinstance(zero_rows, list):
+                zero_rows = []
 
-        merged_by_id: dict[str, dict] = {}
-        for r in [*null_rows, *zero_rows]:
-            if isinstance(r, dict) and r.get("id"):
-                merged_by_id[str(r["id"])] = r
+            merged_by_id: dict[str, dict] = {}
+            for r in [*null_rows, *zero_rows]:
+                if isinstance(r, dict) and r.get("id"):
+                    merged_by_id[str(r["id"])] = r
 
-        rows = list(merged_by_id.values())[: int(limit)]
+            rows = list(merged_by_id.values())[: int(limit)]
         attempted = len(rows)
         updated = 0
 

--- a/backend/tests/test_deal_scoring.py
+++ b/backend/tests/test_deal_scoring.py
@@ -43,3 +43,18 @@ def test_compute_deal_score_missing_data_safe_defaults():
     # With defaults, these should be deterministic
     assert cats.get("crime_index_inverse") == 7.5
     assert cats.get("schools_access") == 9.0
+
+
+def test_compute_deal_score_accepts_yield_and_roi_variants():
+    score, breakdown = compute_deal_score(
+        {
+            "price": 375000,
+            "yield": 6.5,
+            "roi": 12,
+            "rent": 1600,
+        }
+    )
+    cats = breakdown.get("categories") or {}
+    assert score > 0
+    assert cats.get("yield", 0) > 0
+    assert cats.get("roi", 0) > 0

--- a/backend/utils/deal_scoring.py
+++ b/backend/utils/deal_scoring.py
@@ -40,6 +40,14 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _first_float(data: Dict[str, Any], keys: list[str]) -> float | None:
+    for k in keys:
+        v = _to_float(data.get(k))
+        if v is not None:
+            return float(v)
+    return None
+
+
 def compute_deal_score(property_row: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
     """Compute a deterministic 0-100 deal score for a property row.
 
@@ -51,10 +59,45 @@ def compute_deal_score(property_row: Dict[str, Any]) -> Tuple[int, Dict[str, Any
 
     data = property_row or {}
 
-    yield_pct = _to_float(data.get("yield_percent") or data.get("rental_yield_percent")) or 0.0
-    roi_pct = _to_float(data.get("roi_percent")) or 0.0
-    price = _to_float(data.get("price") or data.get("asking_price")) or 0.0
-    rent = _to_float(data.get("rent") or data.get("avg_rent")) or 0.0
+    yield_pct = (
+        _first_float(
+            data,
+            [
+                "yield",
+                "yield_percent",
+                "rental_yield_percent",
+                "rental_yield",
+                "gross_yield",
+                "yieldPercent",
+            ],
+        )
+        or 0.0
+    )
+    roi_pct = (
+        _first_float(
+            data,
+            [
+                "roi",
+                "roi_percent",
+                "annual_roi",
+                "roiPercent",
+            ],
+        )
+        or 0.0
+    )
+    price = (
+        _first_float(
+            data,
+            [
+                "price",
+                "asking_price",
+                "list_price",
+                "askingPrice",
+            ],
+        )
+        or 0.0
+    )
+    rent = _first_float(data, ["rent", "avg_rent"]) or 0.0
 
     # Preserve explicit 0 values; only default on None.
     crime_raw = _to_float(data.get("crime_index"))


### PR DESCRIPTION
Includes fixes for /gpt/score input parsing (reuse shared deterministic scorer) and adds force=true to /properties/admin/backfill-scores for rescoring existing rows.