### PR TITLE
fix(search): fuzzy-match typo locations (e.g. londn -> London)

### DIFF
--- a/backend/search/query.py
+++ b/backend/search/query.py
@@ -244,7 +244,9 @@ def _matches_numeric_filters(row: dict[str, Any], filters: dict[str, Any]) -> bo
     return True
 
 
-def build_search_where(payload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+def build_search_where(
+    payload: dict[str, Any], *, include_similarity: bool = False
+) -> tuple[str, dict[str, Any]]:
     q = _normalize_text(payload.get("q"))
     filters = payload.get("filters") if isinstance(payload.get("filters"), dict) else {}
 
@@ -253,9 +255,23 @@ def build_search_where(payload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
 
     if q:
         params["q"] = f"%{q}%"
-        clauses.append(
-            "(lower(coalesce(title, '')) LIKE :q OR lower(coalesce(location, '')) LIKE :q OR lower(coalesce(postcode, '')) LIKE :q)"
-        )
+        search_clauses = [
+            "lower(coalesce(title, '')) LIKE :q",
+            "lower(coalesce(description, '')) LIKE :q",
+            "lower(coalesce(location, '')) LIKE :q",
+            "lower(coalesce(postcode, '')) LIKE :q",
+        ]
+        if include_similarity:
+            params["q_raw"] = q
+            search_clauses.extend(
+                [
+                    "similarity(lower(coalesce(title, '')), :q_raw) >= 0.2",
+                    "similarity(lower(coalesce(description, '')), :q_raw) >= 0.2",
+                    "similarity(lower(coalesce(location, '')), :q_raw) >= 0.2",
+                    "similarity(lower(coalesce(postcode, '')), :q_raw) >= 0.2",
+                ]
+            )
+        clauses.append(f"({' OR '.join(search_clauses)})")
 
     beds_gte, beds_lte = _extract_range(filters, "beds")
     if beds_gte is not None:
@@ -294,48 +310,58 @@ def query_db(payload: dict[str, Any]) -> dict[str, Any]:
         return {"items": [], "total_results": 0}
 
     safe_payload = payload if isinstance(payload, dict) else {}
-    where_sql, params = build_search_where(safe_payload)
     limit = int(safe_payload.get("limit", 20) or 20)
     offset = int(safe_payload.get("offset", 0) or 0)
     limit = max(1, min(limit, 100))
     offset = max(0, offset)
-
-    params.update({"limit": limit, "offset": offset})
-
-    stmt = text(
-        f"""
-        SELECT
-            id::text,
-            title,
-            description,
-            location,
-            postcode,
-            price,
-            bedrooms,
-            bathrooms,
-            COALESCE(yield, yield_percent) AS yield,
-            yield_percent,
-            roi_percent,
-            source,
-            created_at,
-            count(*) OVER() AS total_results
-        FROM properties
-        WHERE {where_sql}
-        ORDER BY created_at DESC NULLS LAST
-        LIMIT :limit OFFSET :offset
-        """
-    )
 
     engine = create_engine(_postgres_url(), future=True)
     rows: list[dict[str, Any]] = []
     total_results = 0
     try:
         with engine.connect() as conn:
-            rs = conn.execute(stmt, params)
-            for rec in rs.mappings().all():
-                row = dict(rec)
-                total_results = int(row.get("total_results") or 0)
-                rows.append(row)
+
+            def _run(include_similarity: bool) -> tuple[list[dict[str, Any]], int]:
+                where_sql, params = build_search_where(
+                    safe_payload, include_similarity=include_similarity
+                )
+                params.update({"limit": limit, "offset": offset})
+                stmt = text(
+                    f"""
+                    SELECT
+                        id::text,
+                        title,
+                        description,
+                        location,
+                        postcode,
+                        price,
+                        bedrooms,
+                        bathrooms,
+                        COALESCE(yield, yield_percent) AS yield,
+                        yield_percent,
+                        roi_percent,
+                        source,
+                        created_at,
+                        count(*) OVER() AS total_results
+                    FROM properties
+                    WHERE {where_sql}
+                    ORDER BY created_at DESC NULLS LAST
+                    LIMIT :limit OFFSET :offset
+                    """
+                )
+                local_rows: list[dict[str, Any]] = []
+                local_total = 0
+                rs = conn.execute(stmt, params)
+                for rec in rs.mappings().all():
+                    row = dict(rec)
+                    local_total = int(row.get("total_results") or 0)
+                    local_rows.append(row)
+                return local_rows, local_total
+
+            try:
+                rows, total_results = _run(include_similarity=True)
+            except Exception:
+                rows, total_results = _run(include_similarity=False)
     except Exception:
         return {"items": [], "total_results": 0}
     finally:
@@ -353,17 +379,29 @@ def query_db(payload: dict[str, Any]) -> dict[str, Any]:
     ) -> list[str]:
         title = str(row.get("title") or "").lower()
         description = str(row.get("description") or "").lower()
-        tokens = re.split(r"[^\w]+", f"{title} {description}")
+        location = str(row.get("location") or "").lower()
+        postcode = str(row.get("postcode") or "").lower()
+        tokens = re.split(r"[^\w]+", f"{title} {description} {location} {postcode}")
         out: list[str] = []
 
         for term in q_terms:
             if term in tokens:
-                out.append(
-                    f"keyword:title:{term}" if term in title else f"keyword:description:{term}"
-                )
+                if term in title:
+                    out.append(f"keyword:title:{term}")
+                elif term in description:
+                    out.append(f"keyword:description:{term}")
+                elif term in location:
+                    out.append(f"keyword:location:{term}")
+                elif term in postcode:
+                    out.append(f"keyword:postcode:{term}")
             for s in syn.get(term, set()):
                 if s in tokens:
-                    out.append(f"synonym:description:{s}")
+                    if s in location:
+                        out.append(f"synonym:location:{s}")
+                    elif s in postcode:
+                        out.append(f"synonym:postcode:{s}")
+                    else:
+                        out.append(f"synonym:description:{s}")
             for tok in tokens:
                 if tok and difflib.SequenceMatcher(None, term, tok).ratio() > 0.84:
                     out.append(f"fuzzy:{tok}")

--- a/backend/tests/test_search_query_where.py
+++ b/backend/tests/test_search_query_where.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from backend.search.query import build_search_where
+
+
+def test_build_search_where_includes_similarity_for_location_fields() -> None:
+    where_sql, params = build_search_where({"q": "londn"}, include_similarity=True)
+
+    assert "lower(coalesce(location, '')) LIKE :q" in where_sql
+    assert "lower(coalesce(postcode, '')) LIKE :q" in where_sql
+    assert "similarity(lower(coalesce(location, '')), :q_raw) >= 0.2" in where_sql
+    assert "similarity(lower(coalesce(postcode, '')), :q_raw) >= 0.2" in where_sql
+    assert params["q"] == "%londn%"
+    assert params["q_raw"] == "londn"
+
+
+def test_build_search_where_omits_similarity_when_disabled() -> None:
+    where_sql, params = build_search_where({"q": "londn"}, include_similarity=False)
+
+    assert "similarity(" not in where_sql
+    assert params["q"] == "%londn%"
+    assert "q_raw" not in params


### PR DESCRIPTION
## Summary
- Enables SQL-side fuzzy matching for query terms across location-related fields (location, postcode) plus title/description when q is present.
- Adds safe fallback: if similarity() is unavailable (for example, no pg_trgm), query retries with non-similarity clauses instead of returning empty results.
- Extends match metadata tokenization to include location and postcode so typo/synonym evidence can be surfaced in UI badges.
- Adds focused tests for query WHERE construction in backend/tests/test_search_query_where.py.

## Why
Live typo queries like londn were not reliably returning London listings because fuzzy logic was mostly metadata-level and not consistently applied to location fields during SQL filtering.

## Validation
- pytest -q backend/tests/test_search_query_where.py backend/tests/test_search_api_v1.py backend/tests/test_properties_fuzzy_fallback.py