### PR TITLE
Step 5: pg_trgm hardening for smart search

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -52,6 +52,7 @@ from backend.routes.off_market_routes import router as off_market_router
 from backend.routes.properties_routes import router as properties_router
 from backend.routes.save_deal import router as save_deal_router
 from backend.routes.scrape_routes import router as scrape_router
+from backend.routes.search_health import router as search_health_router
 from backend.routes.stripe_routes import router as stripe_routes_router
 from backend.routes.stripe_webhook import router as stripe_webhook_router
 from backend.routes.tradesmen_routes import router as tradesmen_router
@@ -312,6 +313,7 @@ app.include_router(off_market_router)
 app.include_router(save_deal_router)
 app.include_router(properties_router)
 app.include_router(scrape_router)
+app.include_router(search_health_router)
 app.include_router(tradesmen_router)
 app.include_router(admin_schedule.router)
 

--- a/backend/routes/search_health.py
+++ b/backend/routes/search_health.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from backend.search.query import _postgres_url, is_postgres_detected
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health/search")
+def search_health() -> dict[str, object]:
+    if not is_postgres_detected():
+        return {
+            "status": "skipped",
+            "postgres_detected": False,
+            "similarity_available": False,
+            "detail": "Postgres URL is not configured.",
+        }
+
+    try:
+        from sqlalchemy import create_engine, text
+
+        engine = create_engine(_postgres_url(), future=True)
+        try:
+            with engine.connect() as conn:
+                score = conn.execute(
+                    text("SELECT similarity('londn', 'london') AS score")
+                ).scalar_one()
+        finally:
+            engine.dispose()
+
+        return {
+            "status": "ok",
+            "postgres_detected": True,
+            "similarity_available": True,
+            "sample": {"lhs": "londn", "rhs": "london", "score": float(score)},
+        }
+    except Exception as exc:
+        return {
+            "status": "degraded",
+            "postgres_detected": True,
+            "similarity_available": False,
+            "detail": str(exc),
+        }

--- a/backend/tests/test_search_health.py
+++ b/backend/tests/test_search_health.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_health_search_skips_when_postgres_not_detected(monkeypatch) -> None:
+    from backend.routes import search_health
+
+    monkeypatch.setattr(search_health, "is_postgres_detected", lambda: False)
+
+    res = client.get("/health/search")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "skipped"
+    assert body["similarity_available"] is False

--- a/docs/db/pg_trgm_similarity.md
+++ b/docs/db/pg_trgm_similarity.md
@@ -1,0 +1,12 @@
+# Enable pg_trgm for similarity search
+
+The search stack uses PostgreSQL `similarity()` matching for typo tolerance (for example, `londn` → `london`).
+
+Apply migration `supabase/migrations/20260302_enable_pg_trgm_for_search.sql` to ensure:
+
+- `pg_trgm` extension is enabled
+- GIN trigram indexes exist on `properties.title`, `properties.location`, and `properties.postcode` (via `lower(...)` expressions)
+
+After deployment, verify the backend diagnostic endpoint:
+
+- `GET /health/search`

--- a/supabase/migrations/20260302_enable_pg_trgm_for_search.sql
+++ b/supabase/migrations/20260302_enable_pg_trgm_for_search.sql
@@ -1,0 +1,10 @@
+create extension if not exists pg_trgm;
+
+create index if not exists idx_properties_title_trgm
+  on public.properties using gin (lower(title) gin_trgm_ops);
+
+create index if not exists idx_properties_location_trgm
+  on public.properties using gin (lower(location) gin_trgm_ops);
+
+create index if not exists idx_properties_postcode_trgm
+  on public.properties using gin (lower(postcode) gin_trgm_ops);


### PR DESCRIPTION
## What changed
- Added Supabase migration to enable `pg_trgm`
- Added trigram GIN indexes on `lower(title)`, `lower(location)`, and `lower(postcode)`
- Added backend diagnostic endpoint `GET /health/search` that checks `similarity('londn','london')`
- Added docs note: enable pg_trgm for similarity search

## Validation
- `python -m pytest -q backend/tests/test_search_health.py backend/tests/test_search_query_where.py`
- `npm run type-check`
