### PR TITLE
Step 6: complete search click logging end-to-end

### DIFF
--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID
 
@@ -19,6 +20,11 @@ filter_click_total = Counter(
 
 
 class SearchClickEvent(BaseModel):
+    query: str = ""
+    property_id: UUID | None = None
+    position: int | None = Field(default=None, ge=1)
+    filters_json: dict[str, Any] | None = None
+    session_id: str | None = None
     query_id: UUID
     listing_id: UUID
     rank: int | None = Field(default=None, ge=1)
@@ -35,7 +41,36 @@ class FilterSelectEvent(BaseModel):
 def post_search_click(payload: SearchClickEvent) -> dict[str, Any]:
     sb = require_sb()
 
+    property_id = payload.property_id or payload.listing_id
+    position = payload.position if payload.position is not None else payload.rank
+    query_text = str(payload.query or "").strip()
+    session_id = str(payload.session_id or "").strip()
+
+    if session_id and query_text and property_id:
+        dedupe_from = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        try:
+            existing = (
+                sb.schema("analytics")
+                .table("search_clicks")
+                .select("id")
+                .eq("session_id", session_id)
+                .eq("query", query_text)
+                .eq("property_id", str(property_id))
+                .gte("created_at", dedupe_from)
+                .limit(1)
+                .execute()
+            )
+            if existing.data:
+                return {"ok": True, "deduped": True}
+        except Exception:
+            pass
+
     row = {
+        "query": query_text,
+        "property_id": str(property_id),
+        "position": position,
+        "filters_json": payload.filters_json or {},
+        "session_id": session_id,
         "query_id": str(payload.query_id),
         "listing_id": str(payload.listing_id),
         "rank": payload.rank,

--- a/backend/tests/test_events_routes.py
+++ b/backend/tests/test_events_routes.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi.testclient import TestClient
 
 from backend.main import app
@@ -6,24 +8,67 @@ client = TestClient(app)
 
 
 class _FakeTable:
+    def __init__(self, store, name):
+        self._store = store
+        self._name = name
+        self._insert_row = None
+        self._eq_filters = []
+        self._gte_filters = []
+        self._is_select = False
+
+    def select(self, _cols):
+        self._is_select = True
+        return self
+
+    def eq(self, key, value):
+        self._eq_filters.append((key, value))
+        return self
+
+    def gte(self, key, value):
+        self._gte_filters.append((key, value))
+        return self
+
+    def limit(self, _n):
+        return self
+
     def insert(self, _row):
+        self._insert_row = _row
         return self
 
     def execute(self):
+        rows = self._store.setdefault(self._name, [])
+        if self._insert_row is not None:
+            rows.append(self._insert_row)
+            return type("Res", (), {"data": [self._insert_row]})()
+
+        if self._is_select:
+            out = list(rows)
+            for key, value in self._eq_filters:
+                out = [r for r in out if r.get(key) == value]
+            for key, value in self._gte_filters:
+                out = [r for r in out if str(r.get(key, "")) >= str(value)]
+            return type("Res", (), {"data": out[:1]})()
+
         return type("Res", (), {"data": [{"ok": True}]})()
 
 
 class _FakeSchema:
+    def __init__(self, store):
+        self._store = store
+
     def table(self, _name):
-        return _FakeTable()
+        return _FakeTable(self._store, _name)
 
 
 class _FakeSB:
+    def __init__(self):
+        self._store = {}
+
     def schema(self, _name):
-        return _FakeSchema()
+        return _FakeSchema(self._store)
 
     def table(self, _name):
-        return _FakeTable()
+        return _FakeTable(self._store, _name)
 
 
 def test_search_click_event_accepts_valid_payload(monkeypatch):
@@ -76,3 +121,36 @@ def test_filter_select_event_rejects_missing_facet(monkeypatch):
     }
     res = client.post("/events/filter_select", json=body)
     assert res.status_code == 422
+
+
+def test_search_click_event_dedupes_same_session_query_property_within_10s(monkeypatch):
+    from backend.routes import events
+
+    fake_sb = _FakeSB()
+    created_at = (datetime.now(timezone.utc) - timedelta(seconds=3)).isoformat()
+    fake_sb._store["search_clicks"] = [
+        {
+            "id": "1",
+            "session_id": "session-1",
+            "query": "london",
+            "property_id": "4de72852-6a3c-4d1b-9a66-ddf2bafc2ced",
+            "created_at": created_at,
+        }
+    ]
+    monkeypatch.setattr(events, "require_sb", lambda: fake_sb)
+
+    body = {
+        "query": "london",
+        "session_id": "session-1",
+        "property_id": "4de72852-6a3c-4d1b-9a66-ddf2bafc2ced",
+        "position": 1,
+        "filters_json": {"beds": 2},
+        "query_id": "9f5ec88e-6a11-44d5-865e-fdf2d599f165",
+        "listing_id": "4de72852-6a3c-4d1b-9a66-ddf2bafc2ced",
+        "rank": 1,
+    }
+
+    res = client.post("/events/search_click", json=body)
+    assert res.status_code == 200
+    assert res.json().get("deduped") is True
+    assert len(fake_sb._store.get("search_clicks", [])) == 1

--- a/frontend/app/listings/page.tsx
+++ b/frontend/app/listings/page.tsx
@@ -1770,6 +1770,15 @@ function ListingsInner() {
                     isHovered={hoveredId === property.id}
                     onHoverChange={(h) => setHoveredId(h ? property.id : null)}
                     queryId={queryId || null}
+                    queryText={q || qRaw}
+                    filters={{
+                      min: minP,
+                      max: maxP,
+                      beds,
+                      baths,
+                      investment_type: investmentTypeUrl || undefined,
+                      property_type: propertyTypeUrl || undefined,
+                    }}
                     rank={offset + idx + 1}
                   />
                 ))}
@@ -1803,6 +1812,15 @@ function ListingsInner() {
                       isHovered={hoveredId === property.id}
                       onHoverChange={(h) => setHoveredId(h ? property.id : null)}
                       queryId={queryId || null}
+                      queryText={q || qRaw}
+                      filters={{
+                        min: minP,
+                        max: maxP,
+                        beds,
+                        baths,
+                        investment_type: investmentTypeUrl || undefined,
+                        property_type: propertyTypeUrl || undefined,
+                      }}
                       rank={offset + idx + 1}
                     />
                   ))}

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -156,6 +156,8 @@ function SearchInner() {
               bedrooms: item.bedrooms,
               matches: item.matches,
             }}
+            queryText={state.q || 'london'}
+            filters={payload.filters}
             rank={index + 1}
           />
         ))}

--- a/frontend/components/PropertyCard.tsx
+++ b/frontend/components/PropertyCard.tsx
@@ -168,6 +168,8 @@ export default function PropertyCard({
   isHovered,
   onHoverChange,
   queryId,
+  queryText,
+  filters,
   rank,
 }: {
   p: Property;
@@ -175,6 +177,8 @@ export default function PropertyCard({
   isHovered?: boolean;
   onHoverChange?: (hovered: boolean) => void;
   queryId?: string | null;
+  queryText?: string | null;
+  filters?: Record<string, unknown>;
   rank?: number;
 }) {
   const normalized = useMemo(() => normalizeProperty(p as any), [p]);
@@ -523,13 +527,15 @@ export default function PropertyCard({
   const verdict = useMemo(() => buildVerdict(p), [p]);
 
   const handleSearchClickTrack = useCallback(() => {
-    if (!queryId || !p.id) return;
+    if (!p.id) return;
     void track('search_click', {
       queryId,
+      queryText,
       listingId: p.id,
+      filters,
       rank,
     });
-  }, [p.id, queryId, rank]);
+  }, [filters, p.id, queryId, queryText, rank]);
 
   return (
     <article

--- a/frontend/lib/events.ts
+++ b/frontend/lib/events.ts
@@ -2,19 +2,48 @@
 
 import { API_BASE } from '@/lib/api';
 
+const FALLBACK_QUERY_ID = '00000000-0000-4000-8000-000000000000';
+
+function getSessionId(): string {
+  if (typeof window === 'undefined') return 'server';
+  const key = 'propnexus.search.session_id';
+  const existing = window.sessionStorage.getItem(key);
+  if (existing) return existing;
+
+  let next = FALLBACK_QUERY_ID;
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      next = crypto.randomUUID();
+    }
+  } catch {
+    next = FALLBACK_QUERY_ID;
+  }
+  window.sessionStorage.setItem(key, next);
+  return next;
+}
+
 export async function track(eventName: string, payload: Record<string, unknown>): Promise<void> {
   if (eventName !== 'search_click') return;
 
   try {
+    const queryText = String(payload.queryText ?? '').trim();
+    const sessionId = getSessionId();
+
     await fetch(`${API_BASE}/events/search_click`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        query_id: payload.queryId,
+        query: queryText,
+        property_id: payload.listingId,
+        position: payload.rank,
+        filters_json: payload.filters ?? {},
+        session_id: sessionId,
+        query_id: payload.queryId ?? FALLBACK_QUERY_ID,
         listing_id: payload.listingId,
-        rank: payload.rank,
+        rank: payload.rank ?? payload.position,
         user_id: payload.userId,
       }),
+      keepalive: true,
     });
   } catch {
     // best-effort analytics event

--- a/supabase/migrations/20260302_search_clicks_step6_schema.sql
+++ b/supabase/migrations/20260302_search_clicks_step6_schema.sql
@@ -1,0 +1,28 @@
+create schema if not exists analytics;
+
+alter table if exists analytics.search_clicks
+  add column if not exists query text,
+  add column if not exists property_id uuid,
+  add column if not exists position int,
+  add column if not exists filters_json jsonb,
+  add column if not exists session_id text,
+  add column if not exists created_at timestamptz default now();
+
+update analytics.search_clicks
+set
+  property_id = coalesce(property_id, listing_id),
+  position = coalesce(position, rank),
+  filters_json = coalesce(filters_json, '{}'::jsonb),
+  created_at = coalesce(created_at, inserted_at)
+where property_id is null
+   or position is null
+   or filters_json is null
+   or created_at is null;
+
+alter table analytics.search_clicks
+  alter column query set default '',
+  alter column filters_json set default '{}'::jsonb,
+  alter column session_id set default '';
+
+create index if not exists idx_search_clicks_dedupe
+  on analytics.search_clicks (session_id, query, property_id, created_at desc);


### PR DESCRIPTION
What changed\n- Added migration to align analytics.search_clicks with fields: id, query, property_id, position, filters_json, session_id, created_at\n- Added backend dedupe for same session_id+query+property_id within 10 seconds\n- Ensured frontend logs click events from property-card click handlers with query/filter/session context\n- Added backend unit test coverage for dedupe path\n\nValidation\n- python -m pytest -q backend/tests/test_events_routes.py\n- npm run type-check