### PR TITLE
Step 7: add search metrics endpoint and admin dashboard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -37,6 +37,7 @@ from backend.routes import admin_schedule
 from backend.routes.admin_ingestion import router as admin_ingestion_router
 from backend.routes.admin_scrape_runs import router as admin_scrape_runs_router
 from backend.routes.ai import router as ai_router
+from backend.routes.analytics_metrics import router as analytics_metrics_router
 from backend.routes.area_intel_routes import router as area_intel_router
 from backend.routes.comps_routes import router as comps_router
 from backend.routes.debug_properties import router as debug_properties_router
@@ -295,6 +296,7 @@ def _shutdown_worker():
 # 🔌 Routers
 # ======================
 app.include_router(ai_router)
+app.include_router(analytics_metrics_router)
 app.include_router(area_intel_router)
 app.include_router(comps_router)
 app.include_router(debug_properties_router, dependencies=[Depends(require_debug_enabled)])

--- a/backend/routes/analytics_metrics.py
+++ b/backend/routes/analytics_metrics.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from backend.db import require_sb
+from backend.utils.admin_auth import require_admin
+
+router = APIRouter(tags=["analytics"])
+
+
+def _to_int(v: Any, default: int = 0) -> int:
+    try:
+        return int(v)
+    except Exception:
+        return default
+
+
+def _fetch_rows_7d(sb: Any, table: str, cols: str) -> list[dict[str, Any]]:
+    since = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+    try:
+        res = sb.schema("analytics").table(table).select(cols).gte("created_at", since).execute()
+        return list(res.data or [])
+    except Exception:
+        try:
+            res = sb.table(table).select(cols).gte("created_at", since).execute()
+            return list(res.data or [])
+        except Exception:
+            return []
+
+
+@router.get("/analytics/metrics")
+def analytics_metrics(request: Request) -> dict[str, Any]:
+    require_admin(request)
+    sb = require_sb()
+
+    query_rows = _fetch_rows_7d(sb, "search_queries", "query,results_count")
+    click_rows = _fetch_rows_7d(sb, "search_clicks", "id")
+
+    searches_total = len(query_rows)
+    zero_rows = [r for r in query_rows if _to_int(r.get("results_count"), 0) <= 0]
+    zero_results_rate = (len(zero_rows) / searches_total) if searches_total > 0 else 0.0
+    ctr = (len(click_rows) / searches_total) if searches_total > 0 else 0.0
+
+    top_zero_counter: Counter[str] = Counter(
+        str(r.get("query") or "").strip().lower()
+        for r in zero_rows
+        if str(r.get("query") or "").strip()
+    )
+    top_zero_result_queries = [
+        {"query": query, "count": count} for query, count in top_zero_counter.most_common(20)
+    ]
+
+    return {
+        "searches_total": searches_total,
+        "zero_results_rate": round(zero_results_rate, 4),
+        "ctr": round(ctr, 4),
+        "top_zero_result_queries": top_zero_result_queries,
+    }

--- a/backend/routes/properties_routes.py
+++ b/backend/routes/properties_routes.py
@@ -179,9 +179,34 @@ class SearchFiltersPayload(BaseModel):
 class SearchPayload(BaseModel):
     q: str = ""
     filters: SearchFiltersPayload = Field(default_factory=SearchFiltersPayload)
+    session_id: str | None = None
     allow_broaden: bool = True
     limit: int = Field(default=20, ge=1, le=100)
     offset: int = Field(default=0, ge=0)
+
+
+def _log_search_query_metric(payload: dict[str, Any], total_results: int) -> None:
+    query_text = str(payload.get("q") or "").strip()
+    if not query_text:
+        return
+
+    filters = payload.get("filters") if isinstance(payload.get("filters"), dict) else {}
+    row = {
+        "query": query_text,
+        "results_count": int(total_results),
+        "filters_json": filters,
+        "session_id": str(payload.get("session_id") or "").strip() or None,
+    }
+
+    try:
+        sb = _get_supabase()
+        sb.schema("analytics").table("search_queries").insert(row).execute()
+    except Exception:
+        try:
+            sb = _get_supabase()
+            sb.table("search_queries").insert(row).execute()
+        except Exception:
+            return
 
 
 @router.get("/api/v1/search")
@@ -234,6 +259,7 @@ def api_v1_search_with_filters(payload: SearchPayload) -> dict[str, Any]:
         alt_items = alt_queried.get("items") if isinstance(alt_queried, dict) else []
         alt_total = alt_queried.get("total_results") if isinstance(alt_queried, dict) else 0
         alt_out_items = [dict(item) for item in alt_items] if isinstance(alt_items, list) else []
+        _log_search_query_metric(filter_payload, int(alt_total or len(alt_out_items)))
 
         return {
             "results": alt_out_items,
@@ -243,6 +269,7 @@ def api_v1_search_with_filters(payload: SearchPayload) -> dict[str, Any]:
         }
 
     facets = get_facets(filter_payload)
+    _log_search_query_metric(filter_payload, int(total_results or len(out_items)))
 
     return {
         "q": payload.q,

--- a/backend/tests/test_analytics_metrics_route.py
+++ b/backend/tests/test_analytics_metrics_route.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+class _FakeTable:
+    def __init__(self, data: dict[str, list[dict]], name: str):
+        self._data = data
+        self._name = name
+
+    def select(self, _cols: str):
+        return self
+
+    def gte(self, _key: str, _value: str):
+        return self
+
+    def execute(self):
+        return type("Res", (), {"data": list(self._data.get(self._name, []))})()
+
+
+class _FakeSchema:
+    def __init__(self, data: dict[str, list[dict]]):
+        self._data = data
+
+    def table(self, name: str):
+        return _FakeTable(self._data, name)
+
+
+class _FakeSB:
+    def __init__(self, data: dict[str, list[dict]]):
+        self._data = data
+
+    def schema(self, _name: str):
+        return _FakeSchema(self._data)
+
+    def table(self, name: str):
+        return _FakeTable(self._data, name)
+
+
+def test_analytics_metrics_aggregates_7d_values(monkeypatch) -> None:
+    from backend.routes import analytics_metrics
+
+    now = datetime.now(timezone.utc).isoformat()
+    fake = _FakeSB(
+        {
+            "search_queries": [
+                {"query": "londn", "results_count": 0, "created_at": now},
+                {"query": "londn", "results_count": 0, "created_at": now},
+                {"query": "london", "results_count": 3, "created_at": now},
+            ],
+            "search_clicks": [{"id": "1", "created_at": now}, {"id": "2", "created_at": now}],
+        }
+    )
+
+    monkeypatch.setattr(analytics_metrics, "require_admin", lambda _request: None)
+    monkeypatch.setattr(analytics_metrics, "require_sb", lambda: fake)
+
+    res = client.get("/analytics/metrics")
+    assert res.status_code == 200
+
+    body = res.json()
+    assert body["searches_total"] == 3
+    assert body["zero_results_rate"] == 0.6667
+    assert body["ctr"] == 0.6667
+    assert body["top_zero_result_queries"][0] == {"query": "londn", "count": 2}

--- a/backend/tests/test_search_api_v1.py
+++ b/backend/tests/test_search_api_v1.py
@@ -96,3 +96,53 @@ def test_api_v1_search_post_returns_filtered_payload_shape(monkeypatch) -> None:
     assert body["total_results"] == 1
     assert body["items"][0]["id"] == "x1"
     assert body["facets"]["beds"]["3"] == 1
+
+
+def test_api_v1_search_post_logs_search_query_metrics(monkeypatch) -> None:
+    from backend.routes import properties_routes
+
+    inserted_rows: list[dict] = []
+
+    class _FakeTable:
+        def insert(self, row):
+            inserted_rows.append(row)
+            return self
+
+        def execute(self):
+            return type("Res", (), {"data": [{"ok": True}]})()
+
+    class _FakeSchema:
+        def table(self, _name):
+            return _FakeTable()
+
+    class _FakeSB:
+        def schema(self, _name):
+            return _FakeSchema()
+
+        def table(self, _name):
+            return _FakeTable()
+
+    monkeypatch.setattr(properties_routes, "_get_supabase", lambda: _FakeSB())
+    monkeypatch.setattr(
+        properties_routes,
+        "query_db",
+        lambda _payload: {
+            "items": [],
+            "total_results": 0,
+        },
+    )
+    monkeypatch.setattr(properties_routes, "get_facets", lambda _payload: {})
+
+    res = client.post(
+        "/api/v1/search",
+        json={
+            "q": "londn",
+            "allow_broaden": False,
+            "filters": {"price": {"lte": 250000}},
+        },
+    )
+
+    assert res.status_code == 200
+    assert inserted_rows, "Expected search query metric row to be inserted"
+    assert inserted_rows[0]["query"] == "londn"
+    assert inserted_rows[0]["results_count"] == 0

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,4 +1,5 @@
 import { supabaseServer } from "@/lib/supabaseServer";
+import Link from "next/link";
 import AuthStatusPanel from "@/components/admin/AuthStatusPanel";
 import RunImportPanel from "@/components/admin/RunImportPanel";
 
@@ -378,6 +379,19 @@ export default async function AdminPage() {
 
       <div className="mt-8">
         <RunImportPanel />
+      </div>
+
+      <div className="mt-6 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Search Analytics</h2>
+        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          View 7-day search health KPIs and top zero-result queries.
+        </p>
+        <Link
+          href="/admin/search-metrics"
+          className="mt-3 inline-flex text-sm text-brand-600 hover:underline dark:text-brand-400"
+        >
+          Open Search Metrics Dashboard
+        </Link>
       </div>
 
       <div className="mt-8 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">

--- a/frontend/app/admin/search-metrics/page.tsx
+++ b/frontend/app/admin/search-metrics/page.tsx
@@ -1,0 +1,113 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Search Metrics • PropNexus Admin' };
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type ZeroQuery = { query: string; count: number };
+type MetricsResponse = {
+  searches_total: number;
+  zero_results_rate: number;
+  ctr: number;
+  top_zero_result_queries: ZeroQuery[];
+};
+
+function asPercent(v: number): string {
+  return `${(Number(v || 0) * 100).toFixed(1)}%`;
+}
+
+async function loadMetrics(): Promise<MetricsResponse | null> {
+  const enabled = process.env.FEATURE_ADMIN_SEARCH_METRICS === '1';
+  if (!enabled) return null;
+
+  const base =
+    process.env.NEXT_PUBLIC_BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    process.env.NEXT_PUBLIC_API_BASE ||
+    'http://localhost:8000';
+
+  const adminToken = process.env.ADMIN_TOKEN || process.env.IMPORT_ADMIN_TOKEN || '';
+  if (!adminToken) return null;
+
+  const res = await fetch(`${base.replace(/\/$/, '')}/analytics/metrics`, {
+    headers: { 'x-admin-token': adminToken },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) return null;
+  return (await res.json()) as MetricsResponse;
+}
+
+export default async function AdminSearchMetricsPage() {
+  const metrics = await loadMetrics();
+
+  if (!metrics) {
+    return (
+      <main className="mx-auto max-w-4xl px-6 py-12">
+        <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+          Search Metrics
+        </h1>
+        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          This page is behind the `FEATURE_ADMIN_SEARCH_METRICS` flag and requires an admin token.
+        </p>
+        <div className="mt-6">
+          <Link href="/admin" className="text-sm text-brand-600 hover:underline dark:text-brand-400">
+            Back to Admin Dashboard
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+          Search Metrics (7d)
+        </h1>
+        <Link href="/admin" className="text-sm text-brand-600 hover:underline dark:text-brand-400">
+          Back to Admin
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">Searches Total</p>
+          <p className="mt-2 text-3xl font-semibold text-zinc-900 dark:text-zinc-100">
+            {metrics.searches_total}
+          </p>
+        </div>
+        <div className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">Zero Results Rate</p>
+          <p className="mt-2 text-3xl font-semibold text-zinc-900 dark:text-zinc-100">
+            {asPercent(metrics.zero_results_rate)}
+          </p>
+        </div>
+        <div className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">CTR</p>
+          <p className="mt-2 text-3xl font-semibold text-zinc-900 dark:text-zinc-100">
+            {asPercent(metrics.ctr)}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 rounded-xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          Top Zero Result Queries
+        </h2>
+        {metrics.top_zero_result_queries.length === 0 ? (
+          <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">No zero-result searches in the last 7 days.</p>
+        ) : (
+          <ul className="mt-3 space-y-2 text-sm text-zinc-700 dark:text-zinc-300">
+            {metrics.top_zero_result_queries.map((item) => (
+              <li key={item.query} className="flex items-center justify-between">
+                <span>{item.query}</span>
+                <span className="font-medium">{item.count}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/supabase/migrations/20260302_add_search_queries_metrics.sql
+++ b/supabase/migrations/20260302_add_search_queries_metrics.sql
@@ -1,0 +1,19 @@
+create schema if not exists analytics;
+
+create table if not exists analytics.search_queries (
+  id uuid primary key default gen_random_uuid(),
+  query text not null,
+  results_count int not null default 0,
+  filters_json jsonb not null default '{}'::jsonb,
+  session_id text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_search_queries_created_at
+  on analytics.search_queries (created_at desc);
+
+create index if not exists idx_search_queries_query
+  on analytics.search_queries (query);
+
+grant usage on schema analytics to service_role;
+grant insert, select on table analytics.search_queries to service_role;


### PR DESCRIPTION
What changed\n- Added backend endpoint GET /analytics/metrics (admin-token protected)\n- Returns 7-day metrics: searches_total, zero_results_rate, ctr, top_zero_result_queries (top 20)\n- Added migration for analytics.search_queries\n- Added search-query logging for /api/v1/search requests\n- Added feature-flagged admin page at /admin/search-metrics\n\nValidation\n- python -m pytest -q backend/tests/test_analytics_metrics_route.py backend/tests/test_search_api_v1.py\n- npm run type-check\n\nFeature flag\n- Enable FEATURE_ADMIN_SEARCH_METRICS=1 to view admin metrics page