### PR TITLE
Smart Search: location typo tolerance (pg_trgm)

### DIFF
--- a/backend/search/query.py
+++ b/backend/search/query.py
@@ -216,6 +216,36 @@ def _extract_range(filters: dict[str, Any], key: str) -> tuple[float | None, flo
     return (_coerce_optional_float(raw.get("gte")), _coerce_optional_float(raw.get("lte")))
 
 
+def _location_candidate_terms(raw_query: str, *, max_terms: int = 4) -> list[str]:
+    q = _normalize_text(raw_query)
+    if not q:
+        return []
+
+    terms: list[str] = []
+    seen: set[str] = set()
+
+    def _add(term: str) -> None:
+        t = _normalize_text(term)
+        if not t or t in seen:
+            return
+        if len(t) < 3:
+            return
+        if not re.fullmatch(r"[a-z]+", t):
+            return
+        seen.add(t)
+        terms.append(t)
+
+    for token in re.split(r"\s+", q):
+        _add(token)
+        if len(terms) >= max_terms:
+            break
+
+    joined = "".join(ch for ch in q if ch.isalpha())
+    _add(joined)
+
+    return terms[:max_terms]
+
+
 def _matches_numeric_filters(row: dict[str, Any], filters: dict[str, Any]) -> bool:
     beds_gte, beds_lte = _extract_range(filters, "beds")
     price_gte, price_lte = _extract_range(filters, "price")
@@ -263,14 +293,28 @@ def build_search_where(
         ]
         if include_similarity:
             params["q_raw"] = q
+            location_terms = _location_candidate_terms(q)
             search_clauses.extend(
                 [
                     "similarity(lower(coalesce(title, '')), :q_raw) >= 0.2",
                     "similarity(lower(coalesce(description, '')), :q_raw) >= 0.2",
                     "similarity(lower(coalesce(location, '')), :q_raw) >= 0.2",
                     "similarity(lower(coalesce(postcode, '')), :q_raw) >= 0.2",
+                    "lower(coalesce(location, '')) % :q_raw",
+                    "lower(coalesce(postcode, '')) % :q_raw",
                 ]
             )
+
+            for idx, term in enumerate(location_terms):
+                key = f"loc_q_{idx}"
+                params[key] = term
+                search_clauses.extend(
+                    [
+                        f"lower(coalesce(location, '')) % :{key}",
+                        f"lower(coalesce(postcode, '')) % :{key}",
+                        f"word_similarity(:{key}, lower(coalesce(location, ''))) >= 0.55",
+                    ]
+                )
         clauses.append(f"({' OR '.join(search_clauses)})")
 
     beds_gte, beds_lte = _extract_range(filters, "beds")

--- a/backend/tests/test_search_api_v1.py
+++ b/backend/tests/test_search_api_v1.py
@@ -150,6 +150,29 @@ def test_api_v1_search_post_typo_query_returns_results_with_fixture(monkeypatch)
     assert body["items"][0]["location"] == "London"
 
 
+def test_api_v1_search_post_london_and_typo_both_return_results(monkeypatch) -> None:
+    from backend.routes import properties_routes
+
+    fixture_path = Path(__file__).parent / "fixtures" / "search_guardrail_rows.json"
+    rows = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    def _fake_query_db(payload):
+        q = str(payload.get("q") or "").strip().lower()
+        if q in {"london", "londn"}:
+            return {"items": rows[:2], "total_results": 2}
+        return {"items": [], "total_results": 0}
+
+    monkeypatch.setattr(properties_routes, "query_db", _fake_query_db)
+    monkeypatch.setattr(properties_routes, "get_facets", lambda _payload: {})
+
+    for term in ("london", "londn"):
+        res = client.post("/api/v1/search", json={"q": term, "allow_broaden": False, "filters": {}})
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total_results"] > 0
+        assert len(body["items"]) > 0
+
+
 def test_api_v1_search_post_allow_broaden_false_skips_fallback(monkeypatch) -> None:
     from backend.routes import properties_routes
 

--- a/backend/tests/test_search_query_where.py
+++ b/backend/tests/test_search_query_where.py
@@ -10,13 +10,28 @@ def test_build_search_where_includes_similarity_for_location_fields() -> None:
     assert "lower(coalesce(postcode, '')) LIKE :q" in where_sql
     assert "similarity(lower(coalesce(location, '')), :q_raw) >= 0.2" in where_sql
     assert "similarity(lower(coalesce(postcode, '')), :q_raw) >= 0.2" in where_sql
+    assert "lower(coalesce(location, '')) % :q_raw" in where_sql
+    assert "lower(coalesce(postcode, '')) % :q_raw" in where_sql
+    assert "word_similarity(:loc_q_0, lower(coalesce(location, ''))) >= 0.55" in where_sql
     assert params["q"] == "%londn%"
     assert params["q_raw"] == "londn"
+    assert params["loc_q_0"] == "londn"
 
 
 def test_build_search_where_omits_similarity_when_disabled() -> None:
     where_sql, params = build_search_where({"q": "londn"}, include_similarity=False)
 
     assert "similarity(" not in where_sql
+    assert " % :q_raw" not in where_sql
+    assert "word_similarity(" not in where_sql
     assert params["q"] == "%londn%"
     assert "q_raw" not in params
+
+
+def test_build_search_where_tokenizes_location_like_queries() -> None:
+    where_sql, params = build_search_where({"q": "north londn"}, include_similarity=True)
+
+    assert "lower(coalesce(location, '')) % :loc_q_0" in where_sql
+    assert "lower(coalesce(location, '')) % :loc_q_1" in where_sql
+    assert params["loc_q_0"] == "north"
+    assert params["loc_q_1"] == "londn"

--- a/supabase/migrations/20260303_location_typo_tolerance_pg_trgm.sql
+++ b/supabase/migrations/20260303_location_typo_tolerance_pg_trgm.sql
@@ -1,0 +1,26 @@
+create extension if not exists pg_trgm;
+
+create index if not exists idx_properties_location_trgm
+  on public.properties using gin (lower(location) gin_trgm_ops);
+
+create index if not exists idx_properties_postcode_trgm
+  on public.properties using gin (lower(postcode) gin_trgm_ops);
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public' and table_name = 'properties' and column_name = 'city'
+  ) then
+    execute 'create index if not exists idx_properties_city_trgm on public.properties using gin (lower(city) gin_trgm_ops)';
+  end if;
+
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public' and table_name = 'properties' and column_name = 'town'
+  ) then
+    execute 'create index if not exists idx_properties_town_trgm on public.properties using gin (lower(town) gin_trgm_ops)';
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- Adds SQL-level typo tolerance for location search in `build_search_where` using `pg_trgm` operators/functions on `location` and `postcode`.
- Keeps existing text matching behavior for title/description and adds tokenized location-term trigram checks for location-like queries.
- Preserves graceful fallback: if `pg_trgm` operators/functions are unavailable, query execution retries without trigram/similarity and falls back to `ILIKE` clauses.

## Migration
- Added `supabase/migrations/20260303_location_typo_tolerance_pg_trgm.sql`.
- Ensures `pg_trgm` extension exists.
- Index coverage:
  - `lower(location)` GIN trigram index
  - `lower(postcode)` GIN trigram index
  - Conditional indexes for `city` / `town` columns if those columns exist

## Backend changes
- `backend/search/query.py`
  - Added location candidate token extraction for alphabetic terms (`len >= 3`).
  - Added location/postcode trigram predicates (`%`) and `word_similarity(...)` for location fields in similarity-enabled mode.
  - Existing fallback path remains: retry query without trigram/similarity if unsupported.

## Tests
- Updated `backend/tests/test_search_query_where.py` to validate:
  - trigram location clauses are emitted when similarity mode is on
  - no trigram/similarity clauses are emitted when similarity mode is off
  - tokenized location-like queries produce per-term location trigram clauses
- Updated `backend/tests/test_search_api_v1.py` guardrail test to ensure both `london` and `londn` return results (fixture-backed).

## Validation
- `pre-commit run --all-files`
- `pytest -q backend/tests/test_search_query_where.py backend/tests/test_search_api_v1.py`
- `pytest -q`

## Notes
- This specifically targets SQL WHERE-level typo tolerance for location fields to avoid zero-result behavior on misspellings like `londn`.
