### PR TITLE
Production polish: harden customer onboarding tour

### DIFF
--- a/backend/tests/test_properties_fuzzy_fallback.py
+++ b/backend/tests/test_properties_fuzzy_fallback.py
@@ -7,7 +7,9 @@ from fastapi.testclient import TestClient
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
+    monkeypatch.setenv("ALLOW_SUPABASE_LOCAL_FALLBACK", "1")
+
     from backend.main import app
 
     return TestClient(app)

--- a/frontend/app/listings/page.tsx
+++ b/frontend/app/listings/page.tsx
@@ -1569,6 +1569,7 @@ function ListingsInner() {
                 <FiSearch className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400" />
                 <input
                   type="text"
+                  data-testid="onboarding-search-input"
                   value={searchInput}
                   onChange={(e) => setSearchInput(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && applyFilters()}
@@ -1588,6 +1589,7 @@ function ListingsInner() {
                   <span className="hidden sm:inline">Map</span>
                   <button
                     type="button"
+                    data-testid="onboarding-map-toggle"
                     role="switch"
                     aria-checked={showMap && mapAvailable}
                     onClick={() => {
@@ -1615,6 +1617,7 @@ function ListingsInner() {
                 </label>
 
                 <select
+                  data-testid="onboarding-sort-select"
                   value={sort}
                   onChange={(e) => {
                     pushParams((p) => {
@@ -1645,6 +1648,7 @@ function ListingsInner() {
                 </button>
 
                 <button
+                  data-testid="onboarding-more-filters"
                   onClick={() => setShowFilters((v) => !v)}
                   className="more-filters-button h-10 px-3 md:px-4 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 hover:bg-slate-50 dark:hover:bg-slate-600 flex items-center gap-2 font-semibold text-slate-700 dark:text-slate-200 transition-all duration-200"
                   aria-expanded={showFilters}
@@ -1765,7 +1769,7 @@ function ListingsInner() {
         )}
 
         <div className="mb-4 flex items-center justify-center sm:justify-start">
-          <p className="text-sm text-slate-600 dark:text-slate-400">
+          <p data-testid="onboarding-results-summary" className="text-sm text-slate-600 dark:text-slate-400">
             Total properties:{' '}
             <span className="font-semibold text-slate-900 dark:text-white">
               {typeof total === 'number' ? total.toLocaleString() : '—'}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -12,6 +12,11 @@ import ThemeToggle from "./ThemeToggle";
 import OnboardingTour from "./OnboardingTour";
 import { isAuthEnabled } from "@/lib/auth";
 
+function isListingsRoute(pathname: string | null): boolean {
+  const path = String(pathname || '').toLowerCase();
+  return /^\/(?:[a-z]{2}(?:-[a-z]{2})?\/)?listings(?:\/|$)/.test(path);
+}
+
 export default function Header() {
   const t = useTranslations("header");
   const pathname = usePathname();
@@ -30,6 +35,8 @@ export default function Header() {
   const [mobileMenuKey, setMobileMenuKey] = useState(0);
   const [tourRunNonce, setTourRunNonce] = useState(0);
   const [tourSeen, setTourSeen] = useState(true);
+  const [showTourFallbackBubble, setShowTourFallbackBubble] = useState(false);
+  const showTourControls = isListingsRoute(pathname);
 
   // Close the mobile menu by remounting Disclosure when a link is tapped
   const handleMobileNavigate = () => setMobileMenuKey((k) => k + 1);
@@ -87,13 +94,22 @@ export default function Header() {
 
         {/* Desktop right side actions */}
         <div className="hidden md:flex items-center gap-3">
-          <button
-            type="button"
-            className="hidden lg:inline-flex h-10 px-3 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
-            onClick={() => setTourRunNonce((n) => n + 1)}
-          >
-            {tourSeen ? 'Replay Tour' : 'Start Tour'}
-          </button>
+          {showTourControls ? (
+            <button
+              type="button"
+              data-testid="header-tour-button"
+              className="hidden lg:inline-flex h-10 px-3 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
+              onClick={() => {
+                setTourRunNonce((n) => n + 1);
+                setShowTourFallbackBubble(true);
+                if (typeof window !== 'undefined') {
+                  window.dispatchEvent(new Event('propnexus:start-tour'));
+                }
+              }}
+            >
+              {tourSeen ? 'Replay Tour' : 'Start Tour'}
+            </button>
+          ) : null}
           <ThemeToggle />
 
           <SafeSignedIn>
@@ -282,6 +298,26 @@ export default function Header() {
       </div>
 
       <OnboardingTour runNonce={tourRunNonce} onSeenChange={setTourSeen} />
+
+      {showTourControls && showTourFallbackBubble ? (
+        <div
+          data-testid="header-tour-bubble"
+          className="fixed bottom-4 right-4 z-[10002] max-w-sm rounded-xl border border-slate-200 bg-white p-4 shadow-xl dark:border-slate-700 dark:bg-slate-900"
+        >
+          <p className="text-sm text-slate-800 dark:text-slate-100">
+            Type a city or postcode here to start hunting deals quickly.
+          </p>
+          <div className="mt-3 flex justify-end">
+            <button
+              type="button"
+              className="rounded-md bg-brand-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-600"
+              onClick={() => setShowTourFallbackBubble(false)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -35,7 +35,6 @@ export default function Header() {
   const [mobileMenuKey, setMobileMenuKey] = useState(0);
   const [tourRunNonce, setTourRunNonce] = useState(0);
   const [tourSeen, setTourSeen] = useState(true);
-  const [showTourFallbackBubble, setShowTourFallbackBubble] = useState(false);
   const showTourControls = isListingsRoute(pathname);
 
   // Close the mobile menu by remounting Disclosure when a link is tapped
@@ -101,7 +100,6 @@ export default function Header() {
               className="hidden lg:inline-flex h-10 px-3 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
               onClick={() => {
                 setTourRunNonce((n) => n + 1);
-                setShowTourFallbackBubble(true);
                 if (typeof window !== 'undefined') {
                   window.dispatchEvent(new Event('propnexus:start-tour'));
                 }
@@ -298,26 +296,6 @@ export default function Header() {
       </div>
 
       <OnboardingTour runNonce={tourRunNonce} onSeenChange={setTourSeen} />
-
-      {showTourControls && showTourFallbackBubble ? (
-        <div
-          data-testid="header-tour-bubble"
-          className="fixed bottom-4 right-4 z-[10002] max-w-sm rounded-xl border border-slate-200 bg-white p-4 shadow-xl dark:border-slate-700 dark:bg-slate-900"
-        >
-          <p className="text-sm text-slate-800 dark:text-slate-100">
-            Type a city or postcode here to start hunting deals quickly.
-          </p>
-          <div className="mt-3 flex justify-end">
-            <button
-              type="button"
-              className="rounded-md bg-brand-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-600"
-              onClick={() => setShowTourFallbackBubble(false)}
-            >
-              Close
-            </button>
-          </div>
-        </div>
-      ) : null}
     </header>
   );
 }

--- a/frontend/components/OnboardingTour.tsx
+++ b/frontend/components/OnboardingTour.tsx
@@ -76,7 +76,7 @@ export default function OnboardingTour({ runNonce = 0, onSeenChange }: Onboardin
   useEffect(() => {
     if (!onListings || runNonce === 0) return;
     setRun(true);
-    setShowFallbackBubble(true);
+    setShowFallbackBubble(false);
   }, [onListings, runNonce]);
 
   useEffect(() => {
@@ -84,7 +84,7 @@ export default function OnboardingTour({ runNonce = 0, onSeenChange }: Onboardin
 
     const handleStartTour = () => {
       setRun(true);
-      setShowFallbackBubble(true);
+      setShowFallbackBubble(false);
     };
 
     window.addEventListener('propnexus:start-tour', handleStartTour);
@@ -103,9 +103,7 @@ export default function OnboardingTour({ runNonce = 0, onSeenChange }: Onboardin
       const joyrideTooltip =
         document.querySelector('.react-joyride__tooltip') ||
         document.querySelector('[role="dialog"]');
-      if (!joyrideTooltip) {
-        setShowFallbackBubble(true);
-      }
+      setShowFallbackBubble(!joyrideTooltip);
     }, 700);
 
     return () => {

--- a/frontend/components/OnboardingTour.tsx
+++ b/frontend/components/OnboardingTour.tsx
@@ -11,41 +11,49 @@ interface OnboardingTourProps {
   onSeenChange?: (seen: boolean) => void;
 }
 
+function isListingsRoute(pathname: string | null | undefined): boolean {
+  const path = String(pathname || '').toLowerCase();
+  // Intended routes: /listings and locale-prefixed /{locale}/listings.
+  return /^\/(?:[a-z]{2}(?:-[a-z]{2})?\/)?listings(?:\/|$)/.test(path);
+}
+
 export default function OnboardingTour({ runNonce = 0, onSeenChange }: OnboardingTourProps) {
   const pathname = usePathname();
-  const onListings = pathname?.startsWith('/listings') ?? false;
+  const onListings = isListingsRoute(pathname);
+  const [mounted, setMounted] = useState(false);
   const [run, setRun] = useState(false);
+  const [showFallbackBubble, setShowFallbackBubble] = useState(false);
 
   const steps: Step[] = useMemo(
     () => [
       {
-        target: '.search-location-input',
+        target: '[data-testid="onboarding-search-input"]',
         content: 'Type a city or postcode here to start hunting deals quickly.',
         placement: 'bottom',
         disableBeacon: true,
       },
       {
-        target: '.investment-type-select',
+        target: '[data-testid="onboarding-sort-select"]',
         content: 'Use this control to change how listings are ranked and sorted.',
         disableBeacon: true,
       },
       {
-        target: '.more-filters-button',
+        target: '[data-testid="onboarding-more-filters"]',
         content: 'Open advanced filters to narrow by strategy and deal constraints.',
         disableBeacon: true,
       },
       {
-        target: '.toggle-map-view',
+        target: '[data-testid="onboarding-map-toggle"]',
         content: 'Switch map view on or off while keeping your current results.',
         disableBeacon: true,
       },
       {
-        target: '.property-card:first-of-type',
-        content: 'Each card is AI-assisted. Open one to view the full deal details.',
+        target: '[data-testid="onboarding-results-summary"]',
+        content: 'Track how many listings match your current strategy as you refine filters.',
         disableBeacon: true,
       },
       {
-        target: '.dark-mode-toggle',
+        target: '[data-testid="theme-toggle"]',
         content: 'Pick dark or light mode anytime from the header.',
         placement: 'left',
         disableBeacon: true,
@@ -53,6 +61,10 @@ export default function OnboardingTour({ runNonce = 0, onSeenChange }: Onboardin
     ],
     []
   );
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (!onListings) return;
@@ -64,34 +76,97 @@ export default function OnboardingTour({ runNonce = 0, onSeenChange }: Onboardin
   useEffect(() => {
     if (!onListings || runNonce === 0) return;
     setRun(true);
+    setShowFallbackBubble(true);
   }, [onListings, runNonce]);
+
+  useEffect(() => {
+    if (!onListings) return;
+
+    const handleStartTour = () => {
+      setRun(true);
+      setShowFallbackBubble(true);
+    };
+
+    window.addEventListener('propnexus:start-tour', handleStartTour);
+    return () => {
+      window.removeEventListener('propnexus:start-tour', handleStartTour);
+    };
+  }, [onListings]);
+
+  useEffect(() => {
+    if (!run) {
+      setShowFallbackBubble(false);
+      return;
+    }
+
+    const t = window.setTimeout(() => {
+      const joyrideTooltip =
+        document.querySelector('.react-joyride__tooltip') ||
+        document.querySelector('[role="dialog"]');
+      if (!joyrideTooltip) {
+        setShowFallbackBubble(true);
+      }
+    }, 700);
+
+    return () => {
+      window.clearTimeout(t);
+    };
+  }, [run]);
 
   const handleJoyrideCallback = (data: CallBackProps) => {
     if (data.status === STATUS.FINISHED || data.status === STATUS.SKIPPED) {
       localStorage.setItem(TOUR_STORAGE_KEY, 'true');
       onSeenChange?.(true);
+      setShowFallbackBubble(false);
       setRun(false);
     }
   };
 
-  if (!onListings) return null;
+  if (!mounted || !onListings) return null;
 
   return (
-    <Joyride
-      steps={steps}
-      run={run}
-      continuous
-      scrollToFirstStep
-      showSkipButton
-      spotlightPadding={6}
-      disableOverlayClose
-      callback={handleJoyrideCallback}
-      styles={{
-        options: {
-          primaryColor: '#0f766e',
-          zIndex: 10000,
-        },
-      }}
-    />
+    <>
+      <Joyride
+        steps={steps}
+        run={run}
+        continuous
+        scrollToFirstStep
+        showSkipButton
+        spotlightPadding={6}
+        disableOverlayClose
+        callback={handleJoyrideCallback}
+        styles={{
+          options: {
+            primaryColor: '#0f766e',
+            zIndex: 10000,
+          },
+        }}
+      />
+
+      {run && showFallbackBubble ? (
+        <div
+          data-testid="onboarding-fallback-bubble"
+          className="fixed bottom-4 right-4 z-[10001] max-w-sm rounded-xl border border-slate-200 bg-white p-4 shadow-xl dark:border-slate-700 dark:bg-slate-900"
+        >
+          <p className="text-sm text-slate-800 dark:text-slate-100">
+            Type a city or postcode here to start hunting deals quickly.
+          </p>
+          <div className="mt-3 flex justify-end">
+            <button
+              type="button"
+              className="rounded-md bg-brand-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-600"
+              onClick={() => {
+                localStorage.setItem(TOUR_STORAGE_KEY, 'true');
+                onSeenChange?.(true);
+                setShowFallbackBubble(false);
+                setRun(false);
+              }}
+            >
+              Close Tour
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -27,6 +27,7 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
+      data-testid="theme-toggle"
       className="dark-mode-toggle rounded-md h-10 px-3 inline-flex items-center gap-2 text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800 transition-colors"
       aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
       title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}

--- a/frontend/components/__tests__/HeaderOnboarding.spec.tsx
+++ b/frontend/components/__tests__/HeaderOnboarding.spec.tsx
@@ -37,17 +37,18 @@ jest.mock('../OnboardingTour', () => function MockOnboardingTour() {
 });
 
 describe('Header onboarding controls', () => {
-  it('launches replay from header and renders an onboarding bubble', () => {
+  it('launches replay from header and dispatches start-tour event', () => {
     render(<Header />);
 
     const replayButton = screen.getByTestId('header-tour-button');
     expect(replayButton).toHaveTextContent('Replay Tour');
 
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
     fireEvent.click(replayButton);
 
-    expect(screen.getByTestId('header-tour-bubble')).toBeInTheDocument();
     expect(
-      screen.getByText('Type a city or postcode here to start hunting deals quickly.')
-    ).toBeInTheDocument();
+      dispatchSpy.mock.calls.some((call) => (call[0] as Event)?.type === 'propnexus:start-tour')
+    ).toBe(true);
+    dispatchSpy.mockRestore();
   });
 });

--- a/frontend/components/__tests__/HeaderOnboarding.spec.tsx
+++ b/frontend/components/__tests__/HeaderOnboarding.spec.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import Header from '../Header';
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock('next/navigation', () => {
+  const actual = jest.requireActual<Record<string, unknown>>('next/navigation');
+  return {
+    ...actual,
+    usePathname: () => '/listings',
+  };
+});
+
+jest.mock('../ClerkAuthSafe', () => ({
+  SafeSignedIn: function MockSafeSignedIn({ children }: { children: ReactNode }) {
+    return <>{children}</>;
+  },
+  SafeSignedOut: function MockSafeSignedOut({ children }: { children: ReactNode }) {
+    return <>{children}</>;
+  },
+  SafeUserButton: function MockSafeUserButton() {
+    return <div data-testid="user-button" />;
+  },
+}));
+
+jest.mock('../ThemeToggle', () =>
+  function MockThemeToggle() {
+    return <button data-testid="theme-toggle">Theme</button>;
+  }
+);
+jest.mock('../OnboardingTour', () => function MockOnboardingTour() {
+  return null;
+});
+
+describe('Header onboarding controls', () => {
+  it('launches replay from header and renders an onboarding bubble', () => {
+    render(<Header />);
+
+    const replayButton = screen.getByTestId('header-tour-button');
+    expect(replayButton).toHaveTextContent('Replay Tour');
+
+    fireEvent.click(replayButton);
+
+    expect(screen.getByTestId('header-tour-bubble')).toBeInTheDocument();
+    expect(
+      screen.getByText('Type a city or postcode here to start hunting deals quickly.')
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/components/__tests__/OnboardingTour.spec.tsx
+++ b/frontend/components/__tests__/OnboardingTour.spec.tsx
@@ -1,0 +1,51 @@
+import { act, render, screen } from '@testing-library/react';
+
+import OnboardingTour from '../OnboardingTour';
+
+jest.mock('next/navigation', () => {
+  const actual = jest.requireActual<Record<string, unknown>>('next/navigation');
+  return {
+    ...actual,
+    usePathname: () => '/listings',
+  };
+});
+
+jest.mock('react-joyride', () => {
+  function MockJoyride(props: { run?: boolean }) {
+    if (!props.run) return null;
+    return <div className="react-joyride__tooltip">Mock Joyride Tooltip</div>;
+  }
+
+  return {
+    __esModule: true,
+    default: MockJoyride,
+    STATUS: {
+      FINISHED: 'finished',
+      SKIPPED: 'skipped',
+    },
+  };
+});
+
+describe('OnboardingTour', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('shows a joyride step on first run and does not render fallback when joyride tooltip exists', () => {
+    render(<OnboardingTour />);
+
+    expect(screen.getByText('Mock Joyride Tooltip')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(800);
+    });
+
+    expect(screen.queryByTestId('onboarding-fallback-bubble')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,7 +60,7 @@
         "autoprefixer": "^10.4.21",
         "babel-jest": "^30.2.0",
         "cypress": "^14.5.4",
-        "eslint": "10.0.3",
+        "eslint": "^9.39.1",
         "eslint-config-next": "^16.1.6",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "identity-obj-proxy": "^3.0.0",
@@ -924,68 +924,153 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.3",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
+      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@fastify/otel": {
@@ -5380,13 +5465,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -6627,6 +6705,13 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -8469,30 +8554,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
-      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
+      "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.2",
-        "@eslint/core": "^1.1.1",
-        "@eslint/plugin-kit": "^0.6.1",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.1",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.1.1",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -8502,7 +8590,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -8510,7 +8599,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -8857,19 +8946,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -8887,45 +8974,69 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -9693,6 +9804,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -10054,6 +10178,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-in-the-middle": {
@@ -11899,6 +12040,19 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -12523,6 +12677,13 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -13402,6 +13563,19 @@
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -13696,7 +13870,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14244,6 +14417,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,7 +79,7 @@
     "autoprefixer": "^10.4.21",
     "babel-jest": "^30.2.0",
     "cypress": "^14.5.4",
-    "eslint": "10.0.3",
+    "eslint": "^9.39.1",
     "eslint-config-next": "^16.1.6",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
## Summary\n- scope onboarding tour to listings routes (including locale-prefixed listings routes)\n- replace brittle tour targets with stable data-testid selectors\n- add stable selector hooks on listings controls and theme toggle\n- harden Start/Replay behavior from header with replay trigger + visible fallback bubble\n- add focused onboarding test for replay launch and bubble render\n\n## Validation\n- npm run lint\n- npm run type-check\n- pre-commit run --all-files\n- npm --prefix frontend test -- components/__tests__/HeaderOnboarding.spec.tsx