### PR TITLE
Fix property detail Investment Summary production 404/HTML fallback

### DIFF
--- a/frontend/app/api/ai/summary/route.ts
+++ b/frontend/app/api/ai/summary/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function resolveBackendBase(): string {
+  return (
+    process.env.NEXT_PUBLIC_BACKEND_URL ||
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    process.env.NEXT_PUBLIC_API_BASE ||
+    'http://localhost:8000'
+  ).replace(/\/+$/, '');
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const payload = await req.json();
+    const upstream = await fetch(`${resolveBackendBase()}/ai/summary`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      cache: 'no-store',
+    });
+
+    const upstreamType = (upstream.headers.get('content-type') || '').toLowerCase();
+    const status = upstream.status;
+
+    if (!upstream.ok) {
+      if (upstreamType.includes('application/json')) {
+        const errorJson = await upstream.json().catch(() => null as any);
+        const detail =
+          errorJson?.detail ||
+          errorJson?.message ||
+          errorJson?.error ||
+          'Failed to generate summary';
+        return NextResponse.json({ detail: String(detail) }, { status });
+      }
+
+      return NextResponse.json({ detail: 'Failed to generate summary' }, { status });
+    }
+
+    if (!upstreamType.includes('application/json')) {
+      return NextResponse.json({ detail: 'Invalid summary response format' }, { status: 502 });
+    }
+
+    const data = await upstream.json();
+    return NextResponse.json(data, { status });
+  } catch (error) {
+    return NextResponse.json(
+      { detail: error instanceof Error ? error.message : 'Summary proxy error' },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/components/__tests__/InvestmentSummary.spec.tsx
+++ b/frontend/components/__tests__/InvestmentSummary.spec.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import InvestmentSummary from '../property_details/InvestmentSummary';
+import { postAiSummary } from '@/lib/api';
+
+jest.mock('@/lib/api', () => ({
+  postAiSummary: jest.fn(),
+}));
+
+const mockPostAiSummary = postAiSummary as jest.MockedFunction<typeof postAiSummary>;
+
+const propertyFixture = {
+  title: '2-bed terrace',
+  location: 'Leeds',
+  price: 180000,
+  bedrooms: 2,
+  bathrooms: 1,
+  description: 'Solid rental demand in established area',
+};
+
+describe('InvestmentSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders summary content when summary request succeeds', async () => {
+    mockPostAiSummary.mockResolvedValue({
+      summary: 'Strong cashflow profile with scope to increase rent.',
+      bullets: ['Good local demand', 'Below market pricing'],
+    } as any);
+
+    render(<InvestmentSummary property={propertyFixture as any} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('investment-summary-text')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Strong cashflow profile with scope to increase rent.')).toBeInTheDocument();
+    expect(screen.getByText('Good local demand')).toBeInTheDocument();
+  });
+
+  it('renders a safe fallback when summary request fails with non-JSON/404 style error', async () => {
+    mockPostAiSummary.mockRejectedValue(
+      new Error('[POST 404] <!doctype html><html><body><h1>Not Found</h1></body></html>'),
+    );
+
+    render(<InvestmentSummary property={propertyFixture as any} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('investment-summary-fallback')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Summary unavailable')).toBeInTheDocument();
+    expect(
+      screen.getByText('We could not generate an investment summary right now. Please try again later.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/<!doctype html>/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/property_details/InvestmentSummary.tsx
+++ b/frontend/components/property_details/InvestmentSummary.tsx
@@ -25,7 +25,7 @@ const numOrUndef = (v: unknown): number | undefined =>
 
 export default function InvestmentSummary({ property }: Props) {
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState(false);
   const [data, setData] = useState<SummaryResponse | null>(null);
 
   const { title, location, price, bedrooms, bathrooms, propertyType, investmentType, description } = property;
@@ -37,7 +37,7 @@ export default function InvestmentSummary({ property }: Props) {
 
     async function run() {
       setLoading(true);
-      setError(null);
+      setError(false);
       try {
         const payload: SummaryRequest = {
           title,
@@ -55,7 +55,7 @@ export default function InvestmentSummary({ property }: Props) {
         const res = await postAiSummary(payload);
         if (!cancelled) setData(res);
       } catch (e: any) {
-        if (!cancelled) setError(e?.message ?? 'Failed to load summary');
+        if (!cancelled) setError(true);
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -89,12 +89,15 @@ export default function InvestmentSummary({ property }: Props) {
     return (
       <div
         role="alert"
+        data-testid="investment-summary-fallback"
         className="rounded-lg border border-rose-200/60 dark:border-rose-800/30 bg-rose-50 dark:bg-rose-900/10 p-4"
       >
         <div className="text-xs font-semibold uppercase tracking-wide text-rose-700 dark:text-rose-300 mb-1">
           Summary unavailable
         </div>
-        <p className="text-sm text-rose-800 dark:text-rose-200">{error}</p>
+        <p className="text-sm text-rose-800 dark:text-rose-200">
+          We could not generate an investment summary right now. Please try again later.
+        </p>
       </div>
     );
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -79,10 +79,34 @@ export async function apiPost<T = any>(path: string, body: any): Promise<T> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+
+  const contentType = (res.headers.get('content-type') || '').toLowerCase();
+
+  const parseErrorMessage = async (): Promise<string> => {
+    if (contentType.includes('application/json')) {
+      const payload = await res.json().catch(() => null as any);
+      const detail =
+        payload?.detail ||
+        payload?.message ||
+        payload?.error ||
+        (typeof payload === 'string' ? payload : '');
+      if (typeof detail === 'string' && detail.trim()) return detail.trim();
+    }
+
+    if (res.status === 404) return 'Resource not found';
+    if (res.status === 503) return 'Service temporarily unavailable';
+    return res.statusText || 'Request failed';
+  };
+
   if (!res.ok) {
-    const msg = await res.text().catch(() => '');
+    const msg = await parseErrorMessage();
     throw new Error(`[POST ${res.status}] ${msg}`);
   }
+
+  if (!contentType.includes('application/json')) {
+    throw new Error('[POST 502] Invalid server response');
+  }
+
   return (await res.json()) as T;
 }
 


### PR DESCRIPTION
## Summary
- add missing Next proxy route at /api/ai/summary for production /api fallback
- keep summary upstream on backend canonical endpoint /ai/summary
- harden apiPost error parsing so HTML/non-JSON bodies are never surfaced in UI
- update Investment Summary to show a fixed safe fallback message only
- add focused tests for successful rendering and safe fallback behavior

## Root Cause
In production, when NEXT_PUBLIC_API_BASE is not injected, frontend calls fall back to /api.
The Investment Summary call posted to /ai/summary via apiPost, but there was no /api/ai/summary route in Next.
That path could return an HTML 404 page, and the UI displayed the thrown error text directly, exposing raw HTML.

## Validation
- npm run lint
- npm run type-check
- pre-commit run --all-files
- npm test -- --runInBand components/__tests__/InvestmentSummary.spec.tsx
- /workspaces/propnexus-platform/.venv/bin/python -m pytest -q /workspaces/propnexus-platform/backend/tests/test_ai_disabled.py /workspaces/propnexus-platform/backend/tests/test_ai_surface_headers.py
