### PR TITLE
Fix AI Deal Score entitlement gating on property detail

### DIFF
--- a/frontend/app/api/users/plan/route.ts
+++ b/frontend/app/api/users/plan/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function resolveBackendBase(): string {
+  return (
+    process.env.NEXT_PUBLIC_BACKEND_URL ||
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    process.env.NEXT_PUBLIC_API_BASE ||
+    'http://localhost:8000'
+  ).replace(/\/+$/, '');
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const email = req.nextUrl.searchParams.get('email');
+    const upstreamUrl = new URL(`${resolveBackendBase()}/users/plan`);
+    if (email) upstreamUrl.searchParams.set('email', email);
+
+    const authHeader = req.headers.get('authorization');
+    const upstream = await fetch(upstreamUrl.toString(), {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authHeader ? { Authorization: authHeader } : {}),
+      },
+      cache: 'no-store',
+    });
+
+    const upstreamType = (upstream.headers.get('content-type') || '').toLowerCase();
+
+    if (!upstream.ok) {
+      if (upstreamType.includes('application/json')) {
+        const errorJson = await upstream.json().catch(() => null as any);
+        const detail = errorJson?.detail || errorJson?.message || errorJson?.error || 'Plan lookup failed';
+        return NextResponse.json({ detail: String(detail) }, { status: upstream.status });
+      }
+      return NextResponse.json({ detail: 'Plan lookup failed' }, { status: upstream.status });
+    }
+
+    if (!upstreamType.includes('application/json')) {
+      return NextResponse.json({ detail: 'Invalid plan response format' }, { status: 502 });
+    }
+
+    const data = await upstream.json();
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (error) {
+    return NextResponse.json(
+      { detail: error instanceof Error ? error.message : 'Plan proxy error' },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/app/property/[id]/page.tsx
+++ b/frontend/app/property/[id]/page.tsx
@@ -339,6 +339,7 @@ export default function PropertyDetailsPage() {
                 title="AI Deal Score"
                 requiredPlan="pro"
                 featureEnabled={true}
+                showPreviewWhenLocked={false}
               >
                 <DealScore property={property} />
               </GatedPanel>

--- a/frontend/components/LockedFeature.tsx
+++ b/frontend/components/LockedFeature.tsx
@@ -12,6 +12,8 @@ type LockedFeatureProps = {
   message?: string;
   /** Children shown blurred/minimized when locked */
   children?: React.ReactNode;
+  /** Whether to render a blurred preview of children behind lock overlay */
+  showPreview?: boolean;
 };
 
 export default function LockedFeature({
@@ -19,13 +21,14 @@ export default function LockedFeature({
   requiredPlan,
   message,
   children,
+  showPreview = true,
 }: LockedFeatureProps) {
   const defaultMessage = `Upgrade to ${requiredPlan} to unlock this feature`;
 
   return (
     <div className="relative">
       {/* Blurred content preview */}
-      {children && (
+      {children && showPreview && (
         <div
           className="relative overflow-hidden pointer-events-none"
           style={{ maxHeight: '140px' }}

--- a/frontend/components/__tests__/GatedPanelEntitlement.spec.tsx
+++ b/frontend/components/__tests__/GatedPanelEntitlement.spec.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import GatedPanel from '../property_details/GatedPanel';
+import { useUserPlan } from '@/lib/useUserPlan';
+
+jest.mock('@/lib/useUserPlan', () => ({
+  useUserPlan: jest.fn(),
+}));
+
+jest.mock('@/lib/auth', () => ({
+  isAuthEnabled: true,
+}));
+
+jest.mock('@/components/LockedFeature', () => {
+  return function MockLockedFeature({
+    title,
+    message,
+    children,
+    showPreview,
+  }: {
+    title: string;
+    message?: string;
+    children?: ReactNode;
+    showPreview?: boolean;
+  }) {
+    return (
+      <div data-testid="locked-feature">
+        <div>{title}</div>
+        <div>{message}</div>
+        {showPreview && children ? <div data-testid="locked-preview">{children}</div> : null}
+      </div>
+    );
+  };
+});
+
+const mockUseUserPlan = useUserPlan as jest.MockedFunction<typeof useUserPlan>;
+
+describe('GatedPanel entitlement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows unlocked AI Deal Score content for entitled users', () => {
+    mockUseUserPlan.mockReturnValue({
+      plan: 'pro',
+      stripe_customer_id: 'cus_123',
+      loading: false,
+      error: null,
+      refetch: async () => undefined,
+    });
+
+    render(
+      <GatedPanel title="AI Deal Score" requiredPlan="pro" featureEnabled={true} showPreviewWhenLocked={false}>
+        <div data-testid="deal-score-content">Deal score content</div>
+      </GatedPanel>,
+    );
+
+    expect(screen.getByTestId('deal-score-content')).toBeInTheDocument();
+    expect(screen.queryByTestId('locked-feature')).not.toBeInTheDocument();
+  });
+
+  it('shows locked state only for non-entitled users', () => {
+    mockUseUserPlan.mockReturnValue({
+      plan: 'free',
+      stripe_customer_id: null,
+      loading: false,
+      error: null,
+      refetch: async () => undefined,
+    });
+
+    render(
+      <GatedPanel title="AI Deal Score" requiredPlan="pro" featureEnabled={true} showPreviewWhenLocked={false}>
+        <div data-testid="deal-score-content">Deal score content</div>
+      </GatedPanel>,
+    );
+
+    expect(screen.getByTestId('locked-feature')).toBeInTheDocument();
+    expect(
+      screen.getByText('AI Deal Score is available on Pro and Investor plans. Your current plan is Free.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('deal-score-content')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('locked-preview')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/property_details/GatedPanel.tsx
+++ b/frontend/components/property_details/GatedPanel.tsx
@@ -3,7 +3,7 @@
 
 import { ReactNode } from 'react';
 import { useUserPlan } from '@/lib/useUserPlan';
-import { hasAccess } from '@/lib/planPermissions';
+import { getPlanLabel, hasAccess } from '@/lib/planPermissions';
 import LockedFeature from '@/components/LockedFeature';
 import { isAuthEnabled } from '@/lib/auth';
 
@@ -12,6 +12,7 @@ interface GatedPanelProps {
   title: string;
   requiredPlan: 'pro' | 'investor';
   featureEnabled: boolean;
+  showPreviewWhenLocked?: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ export default function GatedPanel({
   title,
   requiredPlan,
   featureEnabled,
+  showPreviewWhenLocked = true,
 }: GatedPanelProps) {
   // Simple local-dev bypass so designers/PMs can preview gated UI
   const bypassGating =
@@ -45,6 +47,7 @@ export default function GatedPanel({
       requiredPlan={requiredPlan}
       featureEnabled={featureEnabled}
       bypassGating={bypassGating}
+      showPreviewWhenLocked={showPreviewWhenLocked}
     >
       {children}
     </GatedPanelAuthed>
@@ -57,6 +60,7 @@ function GatedPanelAuthed({
   requiredPlan,
   featureEnabled,
   bypassGating,
+  showPreviewWhenLocked,
 }: GatedPanelProps & { bypassGating: boolean }) {
   const { plan, loading } = useUserPlan();
 
@@ -75,11 +79,14 @@ function GatedPanelAuthed({
   const userHasAccess = bypassGating || hasAccess(plan, requiredPlan);
 
   if (!userHasAccess) {
+    const requiredLabel = requiredPlan === 'pro' ? 'Pro' : 'Investor';
+    const currentLabel = getPlanLabel(plan);
     return (
       <LockedFeature
         title={title}
-        requiredPlan={requiredPlan === 'pro' ? 'Pro' : 'Investor'}
-        message={`Unlock ${title} with ${requiredPlan === 'pro' ? 'Pro' : 'Investor'} plan`}
+        requiredPlan={requiredLabel}
+        message={`${title} is available on ${requiredLabel} and Investor plans. Your current plan is ${currentLabel}.`}
+        showPreview={showPreviewWhenLocked}
       >
         {children}
       </LockedFeature>


### PR DESCRIPTION
## Summary
- add missing Next proxy route /api/users/plan so entitlement checks work when frontend falls back to /api in production
- keep backend source of truth at /users/plan and preserve plan/customer mapping path
- harden AI Deal Score lock presentation by supporting strict lock-only mode (no blurred score preview)
- improve locked-state copy to explicitly state required plan and current plan
- add focused entitlement tests for unlocked vs locked AI Deal Score behavior

## Root Cause
useUserPlan fetches ${API_BASE}/users/plan. In production, if NEXT_PUBLIC_API_BASE is not injected, API_BASE falls back to /api.
The frontend had no /api/users/plan route, so entitlement lookup could fail and default to free, incorrectly locking AI Deal Score for entitled users.

## Validation
- npm run lint
- npm run type-check
- pre-commit run --all-files
- npm test -- --runInBand components/__tests__/GatedPanelEntitlement.spec.tsx __tests__/lib/planPermissions.spec.tsx
- /workspaces/propnexus-platform/.venv/bin/python -m pytest -q /workspaces/propnexus-platform/backend/tests/test_users_plan_auth_header.py /workspaces/propnexus-platform/backend/tests/test_users_plan_token.py /workspaces/propnexus-platform/backend/tests/test_users_plan_investor.py /workspaces/propnexus-platform/backend/tests/test_stripe_webhook.py -k "plan or investor or price"
