### PR TITLE
Issue #322: map signed-in user to Stripe customer for portal session

### DIFF
--- a/backend/routes/stripe_routes.py
+++ b/backend/routes/stripe_routes.py
@@ -110,9 +110,24 @@ def create_portal_session(payload: PortalRequest):
 
         email = str(payload.email).lower().strip()
 
-        # Try to find customer id in Supabase first
+        # Source of truth: users.stripe_customer_id (webhook-synced)
         customer_id: Optional[str] = None
         if sb:
+            try:
+                rec = (
+                    sb.table("users")
+                    .select("stripe_customer_id")
+                    .eq("email", email)
+                    .maybe_single()
+                    .execute()
+                )
+                if rec.data and rec.data.get("stripe_customer_id"):
+                    customer_id = rec.data["stripe_customer_id"]
+            except Exception:
+                customer_id = None
+
+        # Fallback path: legacy stripe_customers lookup by email
+        if sb and not customer_id:
             try:
                 rec = (
                     sb.table("stripe_customers")

--- a/backend/tests/test_stripe_trial.py
+++ b/backend/tests/test_stripe_trial.py
@@ -149,3 +149,42 @@ def test_webhook_handles_trial_ending(mock_supabase, mock_stripe, client):
     assert mock_supabase.table.return_value.upsert.called
     upsert_call = mock_supabase.table.return_value.upsert.call_args[0][0]
     assert upsert_call["plan_status"] == "active"
+
+
+@patch("backend.routes.stripe_routes.stripe")
+@patch("backend.routes.stripe_routes.sb")
+def test_portal_session_prefers_users_table_customer_id(mock_sb, mock_stripe, client):
+    """Portal lookup should prefer users.stripe_customer_id (webhook synced)."""
+    users_table = Mock()
+    legacy_table = Mock()
+
+    users_table.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = Mock(
+        data={"stripe_customer_id": "cus_from_users_table"}
+    )
+    legacy_table.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = Mock(
+        data={"stripe_customer_id": "cus_from_legacy_table"}
+    )
+
+    def _table(name):
+        if name == "users":
+            return users_table
+        if name == "stripe_customers":
+            return legacy_table
+        return Mock()
+
+    mock_sb.table.side_effect = _table
+
+    mock_portal = Mock(url="https://billing.stripe.com/p/session_test")
+    mock_stripe.billing_portal.Session.create.return_value = mock_portal
+
+    response = client.post(
+        "/stripe/create-portal-session",
+        json={"email": "mapped@example.com"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["url"] == "https://billing.stripe.com/p/session_test"
+
+    call_kwargs = mock_stripe.billing_portal.Session.create.call_args[1]
+    assert call_kwargs["customer"] == "cus_from_users_table"
+    assert not mock_stripe.Customer.search.called

--- a/frontend/__tests__/api-stripe-portal-route.spec.ts
+++ b/frontend/__tests__/api-stripe-portal-route.spec.ts
@@ -1,0 +1,136 @@
+/** @jest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockAuth = jest.fn();
+const mockGetUser = jest.fn();
+
+const mockPortalCreate = jest.fn();
+const mockCustomerSearch = jest.fn();
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+  clerkClient: async () => ({
+    users: {
+      getUser: mockGetUser,
+    },
+  }),
+}));
+
+jest.mock('stripe', () => {
+  return jest.fn().mockImplementation(() => ({
+    billingPortal: {
+      sessions: {
+        create: mockPortalCreate,
+      },
+    },
+    customers: {
+      search: mockCustomerSearch,
+    },
+  }));
+});
+
+describe('/api/stripe/portal', () => {
+  const oldEnv = process.env;
+  const oldFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = {
+      ...oldEnv,
+      STRIPE_SECRET_KEY: 'sk_test_123',
+      NEXT_PUBLIC_BACKEND_URL: 'https://backend.example',
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_test_123',
+      CLERK_SECRET_KEY: 'sk_clerk_123',
+      NEXT_PUBLIC_DISABLE_AUTH: 'false',
+    };
+
+    mockAuth.mockReset();
+    mockGetUser.mockReset();
+    mockPortalCreate.mockReset();
+    mockCustomerSearch.mockReset();
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+    global.fetch = oldFetch;
+  });
+
+  it('returns billing portal URL for an authenticated mapped user', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_1' });
+    mockGetUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: 'mapped@example.com' },
+      emailAddresses: [{ emailAddress: 'mapped@example.com' }],
+    });
+    global.fetch = jest.fn(async () => {
+      return new Response(JSON.stringify({ plan: 'pro', stripe_customer_id: 'cus_mapped_123' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+    mockPortalCreate.mockResolvedValue({ url: 'https://billing.stripe.com/p/session_123' });
+
+    const { POST } = await import('@/app/api/stripe/portal/route');
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, url: 'https://billing.stripe.com/p/session_123' });
+    expect(mockCustomerSearch).not.toHaveBeenCalled();
+  });
+
+  it('returns safe 404 when authenticated user has no mapped Stripe customer', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_2' });
+    mockGetUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: 'nomap@example.com' },
+      emailAddresses: [{ emailAddress: 'nomap@example.com' }],
+    });
+    global.fetch = jest.fn(async () => {
+      return new Response(JSON.stringify({ plan: 'free', stripe_customer_id: null }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+    mockCustomerSearch.mockResolvedValue({ data: [] });
+
+    const { POST } = await import('@/app/api/stripe/portal/route');
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body).toEqual({ ok: false, error: 'No billing account found for your user.' });
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    global.fetch = jest.fn() as any;
+
+    const { POST } = await import('@/app/api/stripe/portal/route');
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ ok: false, error: 'You must be signed in to manage billing.' });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns safe error when Stripe is not configured', async () => {
+    process.env = {
+      ...process.env,
+      STRIPE_SECRET_KEY: '',
+    };
+
+    mockAuth.mockResolvedValue({ userId: 'user_3' });
+    mockGetUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: 'configured@example.com' },
+      emailAddresses: [{ emailAddress: 'configured@example.com' }],
+    });
+
+    const { POST } = await import('@/app/api/stripe/portal/route');
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ ok: false, error: 'Billing portal is not configured right now.' });
+  });
+});

--- a/frontend/app/api/stripe/portal/route.ts
+++ b/frontend/app/api/stripe/portal/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { auth, clerkClient } from '@clerk/nextjs/server';
 import Stripe from 'stripe';
 
 export const runtime = 'nodejs';
@@ -7,29 +8,109 @@ export const dynamic = 'force-dynamic';
 const KEY = process.env.STRIPE_SECRET_KEY;
 const BASE = process.env.NEXT_PUBLIC_APP_BASE_URL ?? '';
 
-/**
- * TODO(#322): Replace with a real lookup that maps the signed-in user
- * to their Stripe customer ID (e.g., from your DB via webhook sync).
- */
-async function getCustomerIdForCurrentUser(): Promise<string | null> {
-  // Return null until you store/lookup real Stripe customer IDs.
+function getBackendBase(): string {
+  const base = (
+    process.env.NEXT_PUBLIC_BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_BASE ||
+    ''
+  ).trim();
+
+  if (base) return base.replace(/\/+$/, '');
+  if (process.env.NODE_ENV !== 'production') return 'http://localhost:8000';
+  throw new Error('Missing backend base URL env (NEXT_PUBLIC_BACKEND_URL / NEXT_PUBLIC_API_URL / BACKEND_URL).');
+}
+
+function isClerkServerEnabled(): boolean {
+  const pk = (process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '').trim();
+  const sk = (process.env.CLERK_SECRET_KEY ?? '').trim();
+  const disable = ['1', 'true', 'yes', 'on'].includes(
+    (process.env.NEXT_PUBLIC_DISABLE_AUTH ?? '').trim().toLowerCase(),
+  );
+  return !disable && pk.startsWith('pk_') && Boolean(sk);
+}
+
+async function getSignedInUserEmail(): Promise<string | null> {
+  if (!isClerkServerEnabled()) return null;
+
+  const a: any = await auth();
+  const userId = (a?.userId as string | null) ?? null;
+  if (!userId) return null;
+
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  return user.primaryEmailAddress?.emailAddress ?? user.emailAddresses?.[0]?.emailAddress ?? null;
+}
+
+async function fetchJsonOrNull(res: Response): Promise<any> {
+  const type = (res.headers.get('content-type') || '').toLowerCase();
+  if (!type.includes('application/json')) return null;
+  return res.json().catch(() => null);
+}
+
+async function getCustomerIdFromUsers(email: string): Promise<string | null> {
+  const res = await fetch(`${getBackendBase()}/users/plan?email=${encodeURIComponent(email)}`, {
+    method: 'GET',
+    headers: { 'content-type': 'application/json' },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    const payload = await fetchJsonOrNull(res);
+    const message = payload?.detail || payload?.message || payload?.error || 'Failed to load billing profile';
+    throw new Error(String(message));
+  }
+
+  const payload = await fetchJsonOrNull(res);
+  const customer = payload?.stripe_customer_id;
+  return typeof customer === 'string' && customer.trim() ? customer.trim() : null;
+}
+
+async function getCustomerIdByEmailFallback(stripe: Stripe, email: string): Promise<string | null> {
+  const existing = await stripe.customers.search({ query: `email:'${email}'`, limit: 1 });
+  if (existing.data?.[0]?.id) return existing.data[0].id;
   return null;
 }
 
 export async function POST() {
   try {
+    if (!isClerkServerEnabled()) {
+      return NextResponse.json(
+        { ok: false, error: 'You must be signed in to manage billing.' },
+        { status: 401 },
+      );
+    }
+
+    const email = await getSignedInUserEmail();
+    if (!email) {
+      return NextResponse.json(
+        { ok: false, error: 'You must be signed in to manage billing.' },
+        { status: 401 },
+      );
+    }
+
     if (!KEY) {
-      return NextResponse.json({ ok: false, error: 'Stripe not configured' }, { status: 500 });
+      return NextResponse.json(
+        { ok: false, error: 'Billing portal is not configured right now.' },
+        { status: 500 },
+      );
     }
 
     const stripe = new Stripe(KEY, { apiVersion: '2025-09-30.clover' });
 
-    const customer = await getCustomerIdForCurrentUser();
+    // Source of truth: users.stripe_customer_id (synced by webhook).
+    let customer = await getCustomerIdFromUsers(email);
+
+    // Email fallback is allowed when existing data paths already support it.
     if (!customer) {
-      // Keep types happy and avoid calling the API without a customer.
+      customer = await getCustomerIdByEmailFallback(stripe, email);
+    }
+
+    if (!customer) {
       return NextResponse.json(
-        { ok: false, error: 'No Stripe customer on file for this user.' },
-        { status: 400 },
+        { ok: false, error: 'No billing account found for your user.' },
+        { status: 404 },
       );
     }
 
@@ -45,6 +126,9 @@ export async function POST() {
       code: err?.code,
       type: err?.type,
     });
-    return NextResponse.json({ ok: false, error: 'Portal failed' }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: 'Could not open billing portal right now.' },
+      { status: 500 },
+    );
   }
 }


### PR DESCRIPTION
## Summary
- implement real signed-in user -> Stripe customer lookup in frontend portal route using existing Clerk server auth pattern
- use users.stripe_customer_id (via /users/plan) as source of truth, then email-based Stripe search fallback only when needed
- return hardened responses for unauthenticated, unmapped customer, and missing Stripe configuration cases
- align backend create-portal-session lookup to prefer users.stripe_customer_id (webhook-synced) before legacy stripe_customers/email fallback
- add focused frontend and backend tests for portal mapping compatibility

## Root Cause
The route frontend/app/api/stripe/portal/route.ts still used a placeholder getCustomerIdForCurrentUser() that always returned null.
As a result, portal session creation could never map the signed-in user to a Stripe customer.
There was also a compatibility gap where backend portal lookup prioritized stripe_customers, while webhook writes stripe_customer_id into users.

## Validation
- npm run lint
- npm run type-check
- pre-commit run --all-files
- npm test -- --runInBand __tests__/api-stripe-portal-route.spec.ts
- /workspaces/propnexus-platform/.venv/bin/python -m pytest -q /workspaces/propnexus-platform/backend/tests/test_stripe_trial.py /workspaces/propnexus-platform/backend/tests/test_stripe_webhook.py /workspaces/propnexus-platform/backend/tests/test_users_plan_auth_header.py /workspaces/propnexus-platform/backend/tests/test_users_plan_token.py /workspaces/propnexus-platform/backend/tests/test_users_plan_investor.py -k "portal or stripe_customer_id or plan"
