### PR TITLE
Stop forwarding untrusted IP headers in AI summary proxy

### DIFF
--- a/frontend/__tests__/api-ai-summary-route.spec.ts
+++ b/frontend/__tests__/api-ai-summary-route.spec.ts
@@ -13,15 +13,16 @@ describe('/api/ai/summary proxy', () => {
     global.fetch = oldFetch;
   });
 
-  it('forwards client IP headers to backend and returns JSON response', async () => {
+  it('does not forward client-supplied IP headers to backend and returns JSON response', async () => {
     process.env.NEXT_PUBLIC_BACKEND_URL = 'https://backend.example';
 
     const fetchMock = jest.fn(async (_url: any, init: any) => {
       const headers = init?.headers as Record<string, string>;
-      expect(headers['x-forwarded-for']).toBe('203.0.113.10');
-      expect(headers['x-real-ip']).toBe('203.0.113.11');
-      expect(headers['cf-connecting-ip']).toBe('203.0.113.12');
-      expect(headers['true-client-ip']).toBe('203.0.113.13');
+      expect(headers['x-forwarded-for']).toBeUndefined();
+      expect(headers['x-real-ip']).toBeUndefined();
+      expect(headers['cf-connecting-ip']).toBeUndefined();
+      expect(headers['true-client-ip']).toBeUndefined();
+      expect(headers['Content-Type']).toBe('application/json');
 
       return new Response(JSON.stringify({ summary: 'OK', bullets: ['One'] }), {
         status: 200,

--- a/frontend/app/api/ai/summary/route.ts
+++ b/frontend/app/api/ai/summary/route.ts
@@ -14,15 +14,11 @@ export async function POST(req: NextRequest) {
   try {
     const payload = await req.json();
 
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    for (const key of ['x-forwarded-for', 'x-real-ip', 'cf-connecting-ip', 'true-client-ip']) {
-      const value = req.headers.get(key);
-      if (value) headers[key] = value;
-    }
-
     const upstream = await fetch(`${resolveBackendBase()}/ai/summary`, {
       method: 'POST',
-      headers,
+      // Do not forward client-controlled IP headers from the request.
+      // Trusted edge/proxy infrastructure should inject source-address headers.
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
       cache: 'no-store',
     });


### PR DESCRIPTION
## Summary
- stop forwarding caller-supplied client IP headers from `/api/ai/summary` to backend
- keep proxy behavior limited to JSON payload forwarding and response normalization
- update proxy test to assert spoofable IP headers are stripped

## Why
Addresses Codex security review: forwarding `x-forwarded-for`/`x-real-ip`/`cf-connecting-ip`/`true-client-ip` directly from client requests can allow identity spoofing and rate-limit evasion if backend trusts forwarded headers.

## Validation
- npm test -- --runInBand __tests__/api-ai-summary-route.spec.ts __tests__/lib/postAiSummary.spec.ts components/__tests__/InvestmentSummary.spec.tsx
- npm run lint
- npm run type-check
- pre-commit run --all-files
