### PR TITLE
Issue #321: add Stripe webhook monitoring instrumentation

### DIFF
--- a/backend/routes/stripe_webhook.py
+++ b/backend/routes/stripe_webhook.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from backend.middleware.rate_limit import WEBHOOK_RATE_LIMIT, is_test_or_ci, limiter
+from backend.utils.sentry_init import capture_exception, capture_message
 from backend.utils.supabase_client import get_supabase
 
 # Set up logger
@@ -19,6 +20,33 @@ logger = logging.getLogger(__name__)
 supabase = None  # will be monkeypatched by tests
 
 router = APIRouter(prefix="/stripe", tags=["stripe"])
+
+
+def _monitor_webhook(
+    message: str,
+    *,
+    level: str = "info",
+    event_type: Optional[str] = None,
+    customer_id: Optional[str] = None,
+    subscription_id: Optional[str] = None,
+    price_id: Optional[str] = None,
+    mapped_plan: Optional[str] = None,
+    db_write_succeeded: Optional[bool] = None,
+    failure_kind: Optional[str] = None,
+) -> None:
+    capture_message(
+        message,
+        level=level,
+        stripe_webhook={
+            "event_type": event_type,
+            "customer_id": customer_id,
+            "subscription_id": subscription_id,
+            "price_id": price_id,
+            "mapped_plan": mapped_plan,
+            "db_write_succeeded": db_write_succeeded,
+            "failure_kind": failure_kind,
+        },
+    )
 
 
 def _stripe_webhook_rate_limit() -> str:
@@ -101,9 +129,9 @@ def _as_dict(obj: Any) -> Dict[str, Any]:
         return {}
 
 
-def _upsert_price_metadata(sb_client: Any, price_id: Optional[str]) -> None:
+def _upsert_price_metadata(sb_client: Any, price_id: Optional[str]) -> bool:
     if not sb_client or not price_id:
-        return
+        return True
 
     try:
         # Stripe API key is required for this call in production.
@@ -111,7 +139,7 @@ def _upsert_price_metadata(sb_client: Any, price_id: Optional[str]) -> None:
         price = _as_dict(price_obj)
     except Exception as e:
         logger.debug(f"Failed to retrieve Stripe price {price_id}: {e}")
-        return
+        return False
 
     data = {
         "stripe_price_id": price_id,
@@ -124,8 +152,10 @@ def _upsert_price_metadata(sb_client: Any, price_id: Optional[str]) -> None:
 
     try:
         sb_client.table("prices").upsert(data, on_conflict="stripe_price_id").execute()
+        return True
     except Exception as e:
         logger.warning(f"Failed to upsert price metadata for {price_id}: {e}")
+        return False
 
 
 def _upsert_subscription_record(
@@ -136,9 +166,9 @@ def _upsert_subscription_record(
     subscription_id: Optional[str],
     status: Optional[str],
     price_id: Optional[str],
-) -> None:
+) -> bool:
     if not sb_client or not email:
-        return
+        return True
 
     data = {
         "email": email,
@@ -151,8 +181,10 @@ def _upsert_subscription_record(
     try:
         # Schema uses a single row per email (email UNIQUE).
         sb_client.table("subscriptions").upsert(data, on_conflict="email").execute()
+        return True
     except Exception as e:
         logger.warning(f"Failed to upsert subscription record for {email}: {e}")
+        return False
 
 
 def _write_user_plan(
@@ -163,9 +195,9 @@ def _write_user_plan(
     plan_status: Optional[str],
     current_period_end: Optional[int],
     plan: Optional[str],
-) -> None:
+) -> bool:
     if not sb_client:
-        return
+        return True
 
     base = {
         "stripe_customer_id": customer_id,
@@ -183,8 +215,10 @@ def _write_user_plan(
             sb_client.table("users").upsert(upsert_data).execute()
         elif customer_id:
             sb_client.table("users").update(base).eq("stripe_customer_id", customer_id).execute()
+        return True
     except Exception as e:
         logger.warning(f"Failed to write user plan data for customer {customer_id}: {e}")
+        return False
 
 
 @router.post("/webhook")
@@ -204,16 +238,40 @@ async def stripe_webhook(request: Request):
     sig_header: str = request.headers.get("Stripe-Signature", "")
     webhook_secret = get_webhook_secret()
 
+    _monitor_webhook(
+        "stripe_webhook_received",
+        level="info",
+        db_write_succeeded=None,
+    )
+
     if not payload:
+        _monitor_webhook(
+            "stripe_webhook_invalid_payload",
+            level="warning",
+            failure_kind="missing_payload",
+            db_write_succeeded=False,
+        )
         return JSONResponse({"ok": False, "error": "missing_payload"}, status_code=400)
 
     # Missing signature header is always a bad request from Stripe's perspective.
     if not sig_header:
+        _monitor_webhook(
+            "stripe_webhook_signature_failure",
+            level="warning",
+            failure_kind="missing_stripe_signature",
+            db_write_succeeded=False,
+        )
         return JSONResponse({"ok": False, "error": "missing_stripe_signature"}, status_code=400)
 
     # Missing secret is a server misconfiguration (should not be a 400).
     if not webhook_secret:
         logger.error("STRIPE_WEBHOOK_SECRET is not set")
+        _monitor_webhook(
+            "stripe_webhook_unexpected_exception",
+            level="error",
+            failure_kind="missing_webhook_secret",
+            db_write_succeeded=False,
+        )
         return JSONResponse({"ok": False, "error": "missing_webhook_secret"}, status_code=500)
 
     # Ensure Stripe client is configured for any retrieve() calls below.
@@ -224,13 +282,32 @@ async def stripe_webhook(request: Request):
             payload=payload, sig_header=sig_header, secret=webhook_secret
         )
     except stripe.error.SignatureVerificationError as e:
+        _monitor_webhook(
+            "stripe_webhook_signature_failure",
+            level="warning",
+            failure_kind="bad_signature",
+            db_write_succeeded=False,
+        )
         return JSONResponse({"ok": False, "error": f"bad_signature:{e}"}, status_code=400)
     except ValueError as e:
         # Raised for invalid JSON / parsing problems.
+        _monitor_webhook(
+            "stripe_webhook_invalid_payload",
+            level="warning",
+            failure_kind="bad_payload",
+            db_write_succeeded=False,
+        )
         return JSONResponse({"ok": False, "error": f"bad_payload:{e}"}, status_code=400)
     except Exception as e:
         # Unexpected failures here are usually configuration/library issues.
         logger.exception(f"Unexpected error constructing Stripe event: {e}")
+        capture_exception(e, stripe_webhook={"failure_kind": "construct_event_exception"})
+        _monitor_webhook(
+            "stripe_webhook_unexpected_exception",
+            level="error",
+            failure_kind="construct_event_exception",
+            db_write_succeeded=False,
+        )
         return JSONResponse({"ok": False, "error": "webhook_internal_error"}, status_code=500)
 
     etype = event.get("type")
@@ -262,12 +339,13 @@ async def stripe_webhook(request: Request):
 
             # Get Supabase client (lazy, may be None)
             sb_client = get_supabase_client()
+            db_write_succeeded = sb_client is not None
 
             if sb_client:
                 try:
                     # Keep admin stats stable by persisting both subscription + price metadata.
-                    _upsert_price_metadata(sb_client, price_id)
-                    _upsert_subscription_record(
+                    price_ok = _upsert_price_metadata(sb_client, price_id)
+                    sub_ok = _upsert_subscription_record(
                         sb_client,
                         email=customer_email,
                         customer_id=customer_id,
@@ -277,7 +355,7 @@ async def stripe_webhook(request: Request):
                     )
 
                     # Users upsert LAST (tests inspect last upsert call).
-                    _write_user_plan(
+                    user_ok = _write_user_plan(
                         sb_client,
                         customer_id=customer_id,
                         email=customer_email,
@@ -285,10 +363,46 @@ async def stripe_webhook(request: Request):
                         current_period_end=current_period_end,
                         plan=plan,
                     )
+                    db_write_succeeded = all([price_ok, sub_ok, user_ok])
+                    if not db_write_succeeded:
+                        _monitor_webhook(
+                            "stripe_webhook_partial_db_write",
+                            level="warning",
+                            event_type=etype,
+                            customer_id=customer_id,
+                            subscription_id=sub_id,
+                            price_id=price_id,
+                            mapped_plan=plan,
+                            db_write_succeeded=False,
+                            failure_kind="db_write_soft_failure",
+                        )
                 except Exception as e:
                     # Log error but don't fail the webhook - gracefully skip DB write
                     logger.warning(f"Failed to upsert user data in checkout.session.completed: {e}")
+                    db_write_succeeded = False
+                    _monitor_webhook(
+                        "stripe_webhook_partial_db_write",
+                        level="warning",
+                        event_type=etype,
+                        customer_id=customer_id,
+                        subscription_id=sub_id,
+                        price_id=price_id,
+                        mapped_plan=plan,
+                        db_write_succeeded=False,
+                        failure_kind="db_write_exception",
+                    )
                     pass
+
+            _monitor_webhook(
+                "stripe_webhook_processed",
+                level="info",
+                event_type=etype,
+                customer_id=customer_id,
+                subscription_id=sub_id,
+                price_id=price_id,
+                mapped_plan=plan,
+                db_write_succeeded=db_write_succeeded,
+            )
 
             return JSONResponse({"ok": True})
 
@@ -321,11 +435,12 @@ async def stripe_webhook(request: Request):
 
             # Get Supabase client (lazy, may be None)
             sb_client = get_supabase_client()
+            db_write_succeeded = sb_client is not None
 
             if sb_client:
                 try:
-                    _upsert_price_metadata(sb_client, price_id)
-                    _upsert_subscription_record(
+                    price_ok = _upsert_price_metadata(sb_client, price_id)
+                    sub_ok = _upsert_subscription_record(
                         sb_client,
                         email=email,
                         customer_id=customer_id,
@@ -334,7 +449,7 @@ async def stripe_webhook(request: Request):
                         price_id=price_id,
                     )
 
-                    _write_user_plan(
+                    user_ok = _write_user_plan(
                         sb_client,
                         customer_id=customer_id,
                         email=email,
@@ -342,10 +457,46 @@ async def stripe_webhook(request: Request):
                         current_period_end=current_period_end,
                         plan=plan,
                     )
+                    db_write_succeeded = all([price_ok, sub_ok, user_ok])
+                    if not db_write_succeeded:
+                        _monitor_webhook(
+                            "stripe_webhook_partial_db_write",
+                            level="warning",
+                            event_type=etype,
+                            customer_id=customer_id,
+                            subscription_id=data_obj.get("id"),
+                            price_id=price_id,
+                            mapped_plan=plan,
+                            db_write_succeeded=False,
+                            failure_kind="db_write_soft_failure",
+                        )
                 except Exception as e:
                     # Log error but don't fail the webhook - gracefully skip DB write
                     logger.warning(f"Failed to upsert user data in subscription.updated: {e}")
+                    db_write_succeeded = False
+                    _monitor_webhook(
+                        "stripe_webhook_partial_db_write",
+                        level="warning",
+                        event_type=etype,
+                        customer_id=customer_id,
+                        subscription_id=data_obj.get("id"),
+                        price_id=price_id,
+                        mapped_plan=plan,
+                        db_write_succeeded=False,
+                        failure_kind="db_write_exception",
+                    )
                     pass
+
+            _monitor_webhook(
+                "stripe_webhook_processed",
+                level="info",
+                event_type=etype,
+                customer_id=customer_id,
+                subscription_id=data_obj.get("id"),
+                price_id=price_id,
+                mapped_plan=plan,
+                db_write_succeeded=db_write_succeeded,
+            )
 
             return JSONResponse({"ok": True})
 
@@ -376,11 +527,12 @@ async def stripe_webhook(request: Request):
 
             # Get Supabase client (lazy, may be None)
             sb_client = get_supabase_client()
+            db_write_succeeded = sb_client is not None
 
             if sb_client:
                 try:
-                    _upsert_price_metadata(sb_client, price_id)
-                    _upsert_subscription_record(
+                    price_ok = _upsert_price_metadata(sb_client, price_id)
+                    sub_ok = _upsert_subscription_record(
                         sb_client,
                         email=email,
                         customer_id=customer_id,
@@ -389,7 +541,7 @@ async def stripe_webhook(request: Request):
                         price_id=price_id,
                     )
 
-                    _write_user_plan(
+                    user_ok = _write_user_plan(
                         sb_client,
                         customer_id=customer_id,
                         email=email,
@@ -397,10 +549,46 @@ async def stripe_webhook(request: Request):
                         current_period_end=current_period_end,
                         plan=plan,
                     )
+                    db_write_succeeded = all([price_ok, sub_ok, user_ok])
+                    if not db_write_succeeded:
+                        _monitor_webhook(
+                            "stripe_webhook_partial_db_write",
+                            level="warning",
+                            event_type=etype,
+                            customer_id=customer_id,
+                            subscription_id=data_obj.get("id"),
+                            price_id=price_id,
+                            mapped_plan=plan,
+                            db_write_succeeded=False,
+                            failure_kind="db_write_soft_failure",
+                        )
                 except Exception as e:
                     # Log error but don't fail the webhook - gracefully skip DB write
                     logger.warning(f"Failed to upsert user data in subscription.created: {e}")
+                    db_write_succeeded = False
+                    _monitor_webhook(
+                        "stripe_webhook_partial_db_write",
+                        level="warning",
+                        event_type=etype,
+                        customer_id=customer_id,
+                        subscription_id=data_obj.get("id"),
+                        price_id=price_id,
+                        mapped_plan=plan,
+                        db_write_succeeded=False,
+                        failure_kind="db_write_exception",
+                    )
                     pass
+
+            _monitor_webhook(
+                "stripe_webhook_processed",
+                level="info",
+                event_type=etype,
+                customer_id=customer_id,
+                subscription_id=data_obj.get("id"),
+                price_id=price_id,
+                mapped_plan=plan,
+                db_write_succeeded=db_write_succeeded,
+            )
 
             return JSONResponse({"ok": True})
 
@@ -420,11 +608,12 @@ async def stripe_webhook(request: Request):
 
             # Get Supabase client (lazy, may be None)
             sb_client = get_supabase_client()
+            db_write_succeeded = sb_client is not None
 
             if sb_client:
                 try:
                     # Mark subscription as canceled if we can identify it.
-                    _upsert_subscription_record(
+                    sub_ok = _upsert_subscription_record(
                         sb_client,
                         email=email,
                         customer_id=customer_id,
@@ -434,7 +623,7 @@ async def stripe_webhook(request: Request):
                     )
 
                     # Downgrade to free plan when subscription is deleted.
-                    _write_user_plan(
+                    user_ok = _write_user_plan(
                         sb_client,
                         customer_id=customer_id,
                         email=email,
@@ -442,15 +631,74 @@ async def stripe_webhook(request: Request):
                         current_period_end=None,
                         plan="free",
                     )
+                    db_write_succeeded = all([sub_ok, user_ok])
+                    if not db_write_succeeded:
+                        _monitor_webhook(
+                            "stripe_webhook_partial_db_write",
+                            level="warning",
+                            event_type=etype,
+                            customer_id=customer_id,
+                            subscription_id=data_obj.get("id"),
+                            mapped_plan="free",
+                            db_write_succeeded=False,
+                            failure_kind="db_write_soft_failure",
+                        )
                 except Exception as e:
                     # Log error but don't fail the webhook - gracefully skip DB write
                     logger.warning(f"Failed to upsert user data in subscription.deleted: {e}")
+                    db_write_succeeded = False
+                    _monitor_webhook(
+                        "stripe_webhook_partial_db_write",
+                        level="warning",
+                        event_type=etype,
+                        customer_id=customer_id,
+                        subscription_id=data_obj.get("id"),
+                        mapped_plan="free",
+                        db_write_succeeded=False,
+                        failure_kind="db_write_exception",
+                    )
                     pass
+
+            _monitor_webhook(
+                "stripe_webhook_processed",
+                level="info",
+                event_type=etype,
+                customer_id=customer_id,
+                subscription_id=data_obj.get("id"),
+                mapped_plan="free",
+                db_write_succeeded=db_write_succeeded,
+            )
 
             return JSONResponse({"ok": True})
 
         # Unhandled but valid
+        _monitor_webhook(
+            "stripe_webhook_processed",
+            level="info",
+            event_type=etype,
+            customer_id=data_obj.get("customer"),
+            subscription_id=data_obj.get("id"),
+            db_write_succeeded=None,
+        )
         return JSONResponse({"ok": True, "ignored": etype})
     except Exception as e:
         # Keep 200 for tests; surface as ok=false so assertions can still read the result
+        capture_exception(
+            e,
+            stripe_webhook={
+                "event_type": etype,
+                "customer_id": data_obj.get("customer"),
+                "subscription_id": data_obj.get("id"),
+                "failure_kind": "unexpected_processing_exception",
+            },
+        )
+        _monitor_webhook(
+            "stripe_webhook_unexpected_exception",
+            level="error",
+            event_type=etype,
+            customer_id=data_obj.get("customer"),
+            subscription_id=data_obj.get("id"),
+            db_write_succeeded=False,
+            failure_kind="unexpected_processing_exception",
+        )
         return JSONResponse({"ok": False, "error": str(e)})

--- a/backend/tests/test_stripe_webhook_monitoring.py
+++ b/backend/tests/test_stripe_webhook_monitoring.py
@@ -1,0 +1,200 @@
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    os.environ["STRIPE_SECRET_KEY"] = "sk_test_fake"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["SUPABASE_URL"] = "https://fake.supabase.co"
+    os.environ["SUPABASE_SERVICE_ROLE_KEY"] = "fake_key"
+
+    from backend.main import app
+
+    return TestClient(app)
+
+
+@patch("backend.routes.stripe_webhook.capture_exception")
+@patch("backend.routes.stripe_webhook.capture_message")
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_webhook_success_instrumentation(
+    mock_stripe, mock_supabase, mock_capture_message, _mock_capture_exception, client
+):
+    mock_event = {
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "customer": "cus_test123",
+                "customer_details": {"email": "test@example.com"},
+                "subscription": "sub_test123",
+            }
+        },
+    }
+    mock_stripe.Webhook.construct_event.return_value = mock_event
+    mock_stripe.Subscription.retrieve.return_value = {
+        "status": "active",
+        "items": {"data": [{"price": {"id": "price_test_123"}}]},
+        "current_period_end": 1234567890,
+    }
+    mock_supabase.table.return_value.upsert.return_value.execute.return_value = Mock(data=[])
+
+    response = client.post(
+        "/stripe/webhook",
+        data=json.dumps(mock_event),
+        headers={"Stripe-Signature": "sig_test"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+    assert any(
+        call.args[0] == "stripe_webhook_received" for call in mock_capture_message.call_args_list
+    )
+    processed_calls = [
+        call
+        for call in mock_capture_message.call_args_list
+        if call.args and call.args[0] == "stripe_webhook_processed"
+    ]
+    assert processed_calls
+    processed_ctx = processed_calls[-1].kwargs.get("stripe_webhook", {})
+    assert processed_ctx.get("event_type") == "checkout.session.completed"
+    assert processed_ctx.get("customer_id") == "cus_test123"
+    assert processed_ctx.get("subscription_id") == "sub_test123"
+    assert processed_ctx.get("price_id") == "price_test_123"
+    assert processed_ctx.get("db_write_succeeded") is True
+
+
+@patch("backend.routes.stripe_webhook.capture_exception")
+@patch("backend.routes.stripe_webhook.capture_message")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_webhook_signature_failure_instrumentation(
+    mock_stripe, mock_capture_message, _mock_capture_exception, client
+):
+    class _SigErr(Exception):
+        pass
+
+    mock_stripe.error.SignatureVerificationError = _SigErr
+    mock_stripe.Webhook.construct_event.side_effect = _SigErr("bad sig")
+
+    response = client.post(
+        "/stripe/webhook",
+        data=json.dumps({"type": "checkout.session.completed", "data": {"object": {}}}),
+        headers={"Stripe-Signature": "sig_bad"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    assert any(
+        call.args[0] == "stripe_webhook_signature_failure"
+        for call in mock_capture_message.call_args_list
+    )
+
+
+@patch("backend.routes.stripe_webhook.capture_exception")
+@patch("backend.routes.stripe_webhook.capture_message")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_webhook_invalid_payload_instrumentation(
+    mock_stripe, mock_capture_message, _mock_capture_exception, client
+):
+    class _SigErr(Exception):
+        pass
+
+    mock_stripe.error.SignatureVerificationError = _SigErr
+    mock_stripe.Webhook.construct_event.side_effect = ValueError("invalid payload")
+
+    response = client.post(
+        "/stripe/webhook",
+        data="not-json",
+        headers={"Stripe-Signature": "sig_test"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    assert any(
+        call.args[0] == "stripe_webhook_invalid_payload"
+        for call in mock_capture_message.call_args_list
+    )
+
+
+@patch("backend.routes.stripe_webhook.capture_exception")
+@patch("backend.routes.stripe_webhook.capture_message")
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_webhook_partial_db_write_soft_failure_instrumentation(
+    mock_stripe, mock_supabase, mock_capture_message, _mock_capture_exception, client
+):
+    mock_event = {
+        "type": "customer.subscription.created",
+        "data": {
+            "object": {
+                "id": "sub_soft_1",
+                "customer": "cus_soft_1",
+                "status": "active",
+                "items": {"data": [{"price": {"id": "price_soft_1"}}]},
+                "current_period_end": 1234567890,
+            }
+        },
+    }
+    mock_stripe.Webhook.construct_event.return_value = mock_event
+    mock_stripe.Customer.retrieve.return_value = {"email": "soft@example.com"}
+
+    mock_supabase.table.return_value.upsert.return_value.execute.side_effect = Exception("db down")
+
+    response = client.post(
+        "/stripe/webhook",
+        data=json.dumps(mock_event),
+        headers={"Stripe-Signature": "sig_test"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    partial_calls = [
+        call
+        for call in mock_capture_message.call_args_list
+        if call.args and call.args[0] == "stripe_webhook_partial_db_write"
+    ]
+    assert partial_calls
+    partial_ctx = partial_calls[-1].kwargs.get("stripe_webhook", {})
+    assert partial_ctx.get("event_type") == "customer.subscription.created"
+    assert partial_ctx.get("customer_id") == "cus_soft_1"
+    assert partial_ctx.get("db_write_succeeded") is False
+
+
+@patch("backend.routes.stripe_webhook.capture_exception")
+@patch("backend.routes.stripe_webhook.capture_message")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_webhook_unexpected_exception_instrumentation(
+    mock_stripe, mock_capture_message, mock_capture_exception, client
+):
+    mock_event = {
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "customer": "cus_boom",
+                "customer_details": {"email": "boom@example.com"},
+                "subscription": "sub_boom",
+            }
+        },
+    }
+    mock_stripe.Webhook.construct_event.return_value = mock_event
+    mock_stripe.Subscription.retrieve.side_effect = Exception("unexpected boom")
+
+    response = client.post(
+        "/stripe/webhook",
+        data=json.dumps(mock_event),
+        headers={"Stripe-Signature": "sig_test"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is False
+
+    assert mock_capture_exception.called
+    assert any(
+        call.args[0] == "stripe_webhook_unexpected_exception"
+        for call in mock_capture_message.call_args_list
+    )


### PR DESCRIPTION
## Summary
- add structured monitoring instrumentation to Stripe webhook lifecycle using existing Sentry helpers (`capture_message` / `capture_exception`)
- instrument request receipt, signature failure, invalid payload, successful processing, partial DB soft failures, and unexpected exceptions
- include safe structured webhook metadata (`event_type`, `customer_id`, `subscription_id`, `price_id`, `mapped_plan`, `db_write_succeeded`) without logging secrets/signatures/raw payloads
- keep webhook response semantics and business behavior unchanged
- add focused webhook monitoring tests for success, signature failure, invalid payload, partial DB write soft failure, and unexpected exception

## Monitoring approach
Used the repository's existing monitoring abstraction in `backend/utils/sentry_init.py` (Sentry-backed capture helpers) to avoid introducing a second system and to keep behavior aligned with production-only reporting configuration.

## Validation
- /workspaces/propnexus-platform/.venv/bin/python -m pytest -q backend/tests/test_stripe_webhook_monitoring.py backend/tests/test_stripe_webhook.py
- pre-commit run --all-files
