### PR TITLE
feat(property): real PDF export actions on property detail (#320)

### DIFF
--- a/frontend/components/property_details/QuickStatsActions.export.spec.tsx
+++ b/frontend/components/property_details/QuickStatsActions.export.spec.tsx
@@ -1,0 +1,93 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import QuickStatsActions from './QuickStatsActions';
+
+const mockExportPropertyPdf = jest.fn();
+const mockFetchWithRetry = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+
+jest.mock('@/lib/propertyPdfExport', () => ({
+  exportPropertyPdf: (...args: unknown[]) => mockExportPropertyPdf(...args),
+}));
+
+jest.mock('@/lib/api', () => ({
+  fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+describe('QuickStatsActions PDF export', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchWithRetry.mockResolvedValue({
+      ok: false,
+      json: async () => ({ data: [] }),
+    });
+    mockExportPropertyPdf.mockResolvedValue(undefined);
+  });
+
+  it('renders export actions in quick actions UI', () => {
+    render(
+      <QuickStatsActions
+        propertyId="prop-123"
+        property={{ title: 'Central Flat', location: 'Leeds' }}
+        price={210000}
+        yieldPercent={6.4}
+        roiPercent={8.1}
+      />,
+    );
+
+    expect(screen.getByText('Quick Actions')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /export/i }).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('executes PDF export handler when export is clicked', async () => {
+    render(
+      <QuickStatsActions
+        propertyId="prop-456"
+        property={{ title: 'Riverside House', location: 'Manchester', bedrooms: 3, bathrooms: 2 }}
+        price={325000}
+        yieldPercent={5.8}
+        roiPercent={7.2}
+        discountPercent={12.3}
+        aiScore={8.9}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export property details as PDF' }));
+
+    await waitFor(() => {
+      expect(mockExportPropertyPdf).toHaveBeenCalledTimes(1);
+      expect(mockToastSuccess).toHaveBeenCalledWith('PDF exported successfully.');
+    });
+
+    expect(mockExportPropertyPdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        propertyId: 'prop-456',
+        price: 325000,
+        yieldPercent: 5.8,
+        roiPercent: 7.2,
+        discountPercent: 12.3,
+        aiScore: 8.9,
+      }),
+    );
+  });
+
+  it('does not crash export flow with sparse property data', async () => {
+    render(<QuickStatsActions propertyId="prop-sparse" property={{}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export property details as PDF' }));
+
+    await waitFor(() => {
+      expect(mockExportPropertyPdf).toHaveBeenCalledTimes(1);
+      expect(mockToastError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/components/property_details/QuickStatsActions.tsx
+++ b/frontend/components/property_details/QuickStatsActions.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { FiHeart, FiShare2, FiDownload, FiCopy, FiCheck } from 'react-icons/fi';
 import { toast } from 'sonner';
 import { fetchWithRetry } from '@/lib/api';
+import { exportPropertyPdf } from '@/lib/propertyPdfExport';
 import { formatPercent, getRoiDisplay, getYieldPercent, normalizeProperty } from '@/lib/normalizeProperty';
 
 type QuickStatsActionsProps = {
@@ -49,6 +50,7 @@ export default function QuickStatsActions({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [exporting, setExporting] = useState(false);
 
   const merged = useMemo(
     () => ({
@@ -141,9 +143,26 @@ export default function QuickStatsActions({
     }
   };
 
-  const handleExportPDF = () => {
-    // TODO(#320): Integrate the quick actions PDF export flow.
-    toast.info('PDF export coming soon!');
+  const handleExportPDF = async () => {
+    try {
+      setExporting(true);
+      await exportPropertyPdf({
+        propertyId,
+        property,
+        url: typeof window !== 'undefined' ? window.location.href : undefined,
+        price: displayPrice,
+        yieldPercent: displayYield,
+        roiPercent: displayRoi,
+        discountPercent,
+        aiScore,
+      });
+      toast.success('PDF exported successfully.');
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to export PDF.');
+    } finally {
+      setExporting(false);
+    }
   };
 
   const handleCopyJSON = async () => {
@@ -274,11 +293,12 @@ export default function QuickStatsActions({
 
               <button
                 onClick={handleExportPDF}
+                disabled={exporting}
                 className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300 font-semibold hover:border-brand-500 hover:text-brand-600 dark:hover:text-brand-400 hover:bg-slate-50 dark:hover:bg-slate-800 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2"
                 aria-label="Export property details as PDF"
               >
                 <FiDownload className="w-5 h-5" aria-hidden="true" />
-                <span>Export PDF</span>
+                <span>{exporting ? 'Exporting…' : 'Export PDF'}</span>
               </button>
 
               <button
@@ -336,6 +356,7 @@ export default function QuickStatsActions({
           </button>
           <button
             onClick={handleExportPDF}
+            disabled={exporting}
             className="flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-sm hover:shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500"
             aria-label="Export as PDF"
           >

--- a/frontend/lib/propertyPdfExport.spec.ts
+++ b/frontend/lib/propertyPdfExport.spec.ts
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom';
+
+import { getPropertyPdfSections } from './propertyPdfExport';
+
+describe('propertyPdfExport rent parsing', () => {
+  it('reads rent_monthly when present', () => {
+    const sections = getPropertyPdfSections({
+      propertyId: 'p1',
+      property: {
+        title: 'Deal 1',
+        location: 'Leeds',
+        rent_monthly: 1450,
+      },
+    });
+
+    expect(sections.metrics).toContainEqual({
+      label: 'Estimated Rent (PCM)',
+      value: '£1,450',
+    });
+  });
+
+  it('parses formatted rent strings like "£1,000 pcm"', () => {
+    const sections = getPropertyPdfSections({
+      propertyId: 'p2',
+      property: {
+        title: 'Deal 2',
+        location: 'London',
+        rent_pcm: '£1,000 pcm',
+      },
+    });
+
+    expect(sections.metrics).toContainEqual({
+      label: 'Estimated Rent (PCM)',
+      value: '£1,000',
+    });
+  });
+
+  it('falls back to N/A when no rent field is parseable', () => {
+    const sections = getPropertyPdfSections({
+      propertyId: 'p3',
+      property: {
+        title: 'Deal 3',
+        location: 'Bristol',
+        rent_pcm: 'unknown',
+      },
+    });
+
+    expect(sections.metrics).toContainEqual({
+      label: 'Estimated Rent (PCM)',
+      value: 'N/A',
+    });
+  });
+});

--- a/frontend/lib/propertyPdfExport.ts
+++ b/frontend/lib/propertyPdfExport.ts
@@ -1,0 +1,237 @@
+'use client';
+
+type ExportMetric = {
+  label: string;
+  value: string;
+};
+
+export type PropertyPdfExportInput = {
+  propertyId: string;
+  property?: Record<string, unknown> | null;
+  url?: string;
+  price?: number;
+  yieldPercent?: number;
+  roiPercent?: number;
+  discountPercent?: number;
+  aiScore?: number;
+};
+
+const toNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+};
+
+const formatCurrency = (value: number | undefined): string => {
+  if (typeof value !== 'number') return 'N/A';
+  return new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: 'GBP',
+    maximumFractionDigits: 0,
+  }).format(value);
+};
+
+const formatPercent = (value: number | undefined): string => {
+  if (typeof value !== 'number') return 'N/A';
+  return `${value.toFixed(1)}%`;
+};
+
+const formatDate = (): string => {
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date());
+};
+
+const sanitizeFilenamePart = (value: string): string => {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 40);
+};
+
+const getText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+const escapeHtml = (value: string): string => {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+
+const normalizeLineBreaks = (value: string): string => {
+  return escapeHtml(value).replace(/\n/g, '<br/>');
+};
+
+export const createPropertyPdfFilename = (input: PropertyPdfExportInput): string => {
+  const property = input.property ?? {};
+  const title = getText(property.title);
+  const location = getText(property.location);
+  const idPart = sanitizeFilenamePart(input.propertyId || 'property');
+  const titlePart = sanitizeFilenamePart(title ?? location ?? 'property-details');
+  const ymd = new Date().toISOString().slice(0, 10);
+  return `propnexus-${titlePart}-${idPart}-${ymd}.pdf`;
+};
+
+export const getPropertyPdfSections = (input: PropertyPdfExportInput): {
+  heading: string;
+  subtitle: string;
+  metrics: ExportMetric[];
+  overview: ExportMetric[];
+  notes: string;
+} => {
+  const property = input.property ?? {};
+  const title = getText(property.title) ?? `Property ${input.propertyId}`;
+  const location = getText(property.location) ?? 'Location unavailable';
+
+  const price = typeof input.price === 'number' ? input.price : toNumber(property.price);
+  const rent =
+    toNumber(property.monthly_rent) ??
+    toNumber(property.rent_pcm) ??
+    toNumber(property.rent_per_month) ??
+    toNumber(property.rent);
+
+  const metrics: ExportMetric[] = [
+    { label: 'Price', value: formatCurrency(price) },
+    { label: 'Estimated Rent (PCM)', value: formatCurrency(rent) },
+    { label: 'Yield', value: formatPercent(input.yieldPercent) },
+    { label: 'ROI', value: formatPercent(input.roiPercent) },
+    { label: 'Discount', value: formatPercent(input.discountPercent) },
+    {
+      label: 'AI Score',
+      value: typeof input.aiScore === 'number' ? `${input.aiScore.toFixed(1)}/10` : 'N/A',
+    },
+  ];
+
+  const overview: ExportMetric[] = [
+    { label: 'Property ID', value: input.propertyId || 'N/A' },
+    { label: 'Title', value: title },
+    { label: 'Location', value: location },
+    { label: 'Property Type', value: getText(property.propertyType ?? property.property_type) ?? 'N/A' },
+    { label: 'Investment Type', value: getText(property.investmentType ?? property.investment_type) ?? 'N/A' },
+    {
+      label: 'Bedrooms / Bathrooms',
+      value: `${toNumber(property.bedrooms) ?? 'N/A'} / ${toNumber(property.bathrooms) ?? 'N/A'}`,
+    },
+    { label: 'Exported At', value: formatDate() },
+    { label: 'Source URL', value: input.url ?? 'N/A' },
+  ];
+
+  const notes = getText(property.description) ?? 'No description provided.';
+
+  return {
+    heading: 'PropNexus Property Deal Export',
+    subtitle: `${title} - ${location}`,
+    metrics,
+    overview,
+    notes,
+  };
+};
+
+const toList = (items: ExportMetric[]): string => {
+  return items
+    .map(
+      (item) => `
+        <div class="row">
+          <div class="label">${escapeHtml(item.label)}</div>
+          <div class="value">${escapeHtml(item.value)}</div>
+        </div>
+      `,
+    )
+    .join('');
+};
+
+const buildMarkup = (input: PropertyPdfExportInput): string => {
+  const sections = getPropertyPdfSections(input);
+
+  return `
+    <div class="export-root">
+      <style>
+        .export-root { font-family: Arial, sans-serif; color: #0f172a; padding: 22px; background: #ffffff; }
+        h1 { font-size: 22px; margin: 0; color: #0f172a; }
+        .subtitle { margin-top: 6px; font-size: 13px; color: #475569; }
+        .chip { display: inline-block; margin-top: 12px; font-size: 11px; padding: 5px 10px; border: 1px solid #cbd5e1; border-radius: 9999px; color: #334155; }
+        .section { margin-top: 18px; border: 1px solid #e2e8f0; border-radius: 10px; overflow: hidden; }
+        .section-title { font-size: 13px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; padding: 10px 12px; background: #f8fafc; border-bottom: 1px solid #e2e8f0; }
+        .section-body { padding: 8px 12px; }
+        .row { display: flex; justify-content: space-between; gap: 20px; border-bottom: 1px solid #f1f5f9; padding: 8px 0; }
+        .row:last-child { border-bottom: none; }
+        .label { font-size: 12px; color: #64748b; }
+        .value { font-size: 13px; font-weight: 600; text-align: right; color: #0f172a; }
+        .notes { margin-top: 10px; font-size: 12px; line-height: 1.55; color: #1e293b; }
+        .footer { margin-top: 16px; font-size: 11px; color: #64748b; border-top: 1px solid #e2e8f0; padding-top: 10px; }
+      </style>
+
+      <h1>${escapeHtml(sections.heading)}</h1>
+      <div class="subtitle">${escapeHtml(sections.subtitle)}</div>
+      <div class="chip">Key sections: Deal Metrics, Overview, Notes</div>
+
+      <div class="section">
+        <div class="section-title">Deal Metrics</div>
+        <div class="section-body">${toList(sections.metrics)}</div>
+      </div>
+
+      <div class="section">
+        <div class="section-title">Property Overview</div>
+        <div class="section-body">${toList(sections.overview)}</div>
+      </div>
+
+      <div class="section">
+        <div class="section-title">Notes</div>
+        <div class="section-body">
+          <div class="notes">${normalizeLineBreaks(sections.notes)}</div>
+        </div>
+      </div>
+
+      <div class="footer">Generated by PropNexus property detail export.</div>
+    </div>
+  `;
+};
+
+export async function exportPropertyPdf(input: PropertyPdfExportInput): Promise<void> {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    throw new Error('PDF export is only available in the browser.');
+  }
+
+  const html2pdfModule = await import('html2pdf.js');
+  const html2pdf = (html2pdfModule.default ?? html2pdfModule) as any;
+
+  const mountNode = document.createElement('div');
+  mountNode.setAttribute('data-testid', 'property-export-pdf-root');
+  mountNode.style.position = 'fixed';
+  mountNode.style.left = '-10000px';
+  mountNode.style.top = '0';
+  mountNode.style.width = '780px';
+  mountNode.style.zIndex = '-1';
+  mountNode.innerHTML = buildMarkup(input);
+
+  document.body.appendChild(mountNode);
+
+  try {
+    await html2pdf()
+      .set({
+        margin: [10, 10, 10, 10],
+        filename: createPropertyPdfFilename(input),
+        image: { type: 'jpeg', quality: 0.96 },
+        html2canvas: { scale: 2, useCORS: true, backgroundColor: '#ffffff' },
+        jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+      })
+      .from(mountNode)
+      .save();
+  } finally {
+    mountNode.remove();
+  }
+}

--- a/frontend/lib/propertyPdfExport.ts
+++ b/frontend/lib/propertyPdfExport.ts
@@ -25,6 +25,42 @@ const toNumber = (value: unknown): number | undefined => {
   return undefined;
 };
 
+const toCurrencyNumber = (value: unknown): number | undefined => {
+  const direct = toNumber(value);
+  if (typeof direct === 'number') return direct;
+  if (typeof value !== 'string') return undefined;
+
+  const normalized = value
+    .trim()
+    .replace(/,/g, '')
+    .replace(/[\u00A0\s]+/g, ' ')
+    .toLowerCase();
+
+  const match = normalized.match(/-?\d+(?:\.\d+)?/);
+  if (!match) return undefined;
+  const parsed = Number(match[0]);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const resolveRentMonthly = (property: Record<string, unknown>): number | undefined => {
+  const rentCandidates: unknown[] = [
+    property.monthly_rent,
+    property.rent_monthly,
+    property.monthlyRent,
+    property.rent_pcm,
+    property.rent_per_month,
+    property.rentPerMonth,
+    property.rent,
+  ];
+
+  for (const candidate of rentCandidates) {
+    const parsed = toCurrencyNumber(candidate);
+    if (typeof parsed === 'number') return parsed;
+  }
+
+  return undefined;
+};
+
 const formatCurrency = (value: number | undefined): string => {
   if (typeof value !== 'number') return 'N/A';
   return new Intl.NumberFormat('en-GB', {
@@ -98,11 +134,7 @@ export const getPropertyPdfSections = (input: PropertyPdfExportInput): {
   const location = getText(property.location) ?? 'Location unavailable';
 
   const price = typeof input.price === 'number' ? input.price : toNumber(property.price);
-  const rent =
-    toNumber(property.monthly_rent) ??
-    toNumber(property.rent_pcm) ??
-    toNumber(property.rent_per_month) ??
-    toNumber(property.rent);
+  const rent = resolveRentMonthly(property);
 
   const metrics: ExportMetric[] = [
     { label: 'Price', value: formatCurrency(price) },


### PR DESCRIPTION
## Summary\n- replace placeholder Quick Actions PDF export with a real browser PDF generation flow\n- add production-safe export utility with meaningful filenames and sparse-data-safe fallbacks\n- include key deal sections in export (Deal Metrics, Property Overview, Notes) based on current property detail data\n- add focused Jest coverage for export action rendering, handler execution, and sparse property safety\n\n## Validation\n- npm run lint\n- npm run type-check\n- pre-commit run --all-files\n- cd frontend && npm test -- QuickStatsActions.export.spec.tsx --runInBand\n\nCloses #320