### PR TITLE
Harden billing portal and plan lookup for soft launch

### DIFF
--- a/frontend/__tests__/api-stripe-portal-route.spec.ts
+++ b/frontend/__tests__/api-stripe-portal-route.spec.ts
@@ -98,7 +98,7 @@ describe('/api/stripe/portal', () => {
     const body = await res.json();
 
     expect(res.status).toBe(404);
-    expect(body).toEqual({ ok: false, error: 'No billing account found for your user.' });
+    expect(body).toEqual({ ok: false, error: 'No billing account found for your signed-in user.' });
   });
 
   it('rejects unauthenticated requests', async () => {

--- a/frontend/__tests__/api-users-plan-route.spec.ts
+++ b/frontend/__tests__/api-users-plan-route.spec.ts
@@ -1,0 +1,102 @@
+/** @jest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockAuth = jest.fn();
+const mockGetUser = jest.fn();
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+  clerkClient: async () => ({
+    users: {
+      getUser: mockGetUser,
+    },
+  }),
+}));
+
+describe('/api/users/plan', () => {
+  const oldEnv = process.env;
+  const oldFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = {
+      ...oldEnv,
+      NEXT_PUBLIC_BACKEND_URL: 'https://backend.example',
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_test_123',
+      CLERK_SECRET_KEY: 'sk_clerk_123',
+      NEXT_PUBLIC_DISABLE_AUTH: 'false',
+    };
+
+    mockAuth.mockReset();
+    mockGetUser.mockReset();
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+    global.fetch = oldFetch;
+  });
+
+  it('returns plan for valid upstream payload', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_1' });
+    mockGetUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: 'user@example.com' },
+      emailAddresses: [{ emailAddress: 'user@example.com' }],
+    });
+    global.fetch = jest.fn(async () => {
+      return new Response(JSON.stringify({ plan: 'pro' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    const { GET } = await import('@/app/api/users/plan/route');
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ plan: 'pro' });
+  });
+
+  it('rejects malformed upstream payload with 502', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_2' });
+    mockGetUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: 'user2@example.com' },
+      emailAddresses: [{ emailAddress: 'user2@example.com' }],
+    });
+    global.fetch = jest.fn(async () => {
+      return new Response('not-json', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      });
+    }) as any;
+
+    const { GET } = await import('@/app/api/users/plan/route');
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body).toEqual({ detail: 'Invalid plan response format' });
+  });
+
+  it('rejects missing plan field with 502', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_3' });
+    mockGetUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: 'user3@example.com' },
+      emailAddresses: [{ emailAddress: 'user3@example.com' }],
+    });
+    global.fetch = jest.fn(async () => {
+      return new Response(JSON.stringify({ stripe_customer_id: 'cus_123' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    const { GET } = await import('@/app/api/users/plan/route');
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body).toEqual({ detail: 'Invalid plan response format' });
+  });
+});

--- a/frontend/app/account/page.tsx
+++ b/frontend/app/account/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, Suspense } from 'react';
+import { useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useUser } from '@clerk/nextjs';
@@ -15,8 +15,6 @@ export const dynamic = 'force-dynamic';
 
 function AccountPageContent() {
   const searchParams = useSearchParams();
-  const [loadingPortal, setLoadingPortal] = useState(false);
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const { refetch: refetchPlan } = useUserPlan();
 
   const { isLoaded: clerkLoaded, isSignedIn, user } = useUser();
@@ -25,17 +23,13 @@ function AccountPageContent() {
 
   useEffect(() => {
     (async () => {
-      // Check if returning from Stripe checkout success
       if (searchParams) {
         const success = searchParams.get('success');
         const sessionId = searchParams.get('session_id');
 
         if (success === 'true' && sessionId) {
-          // Show success message
           toast.success('Subscription updated successfully!');
 
-          // Refresh plan data to reflect the change
-          // Use a small delay to allow webhook processing
           setTimeout(async () => {
             try {
               await refetchPlan();
@@ -48,43 +42,6 @@ function AccountPageContent() {
       }
     })();
   }, [searchParams, refetchPlan]);
-
-  /** Manual/fallback Customer Portal opener (kept visible for redundancy) */
-  async function openPortalManually() {
-    const email = effectiveUser?.primaryEmailAddress?.emailAddress;
-    if (!email) return;
-    setErrorMsg(null);
-    setLoadingPortal(true);
-
-    const controller = new AbortController();
-    const t = setTimeout(() => controller.abort(), 20_000);
-
-    try {
-      const res = await fetch(`/api/stripe/create-portal-session`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
-        signal: controller.signal,
-      });
-
-      if (!res.ok) {
-        let detail = '';
-        try {
-          detail = (await res.json())?.detail ?? '';
-        } catch {}
-        throw new Error(detail || `Portal request failed (${res.status})`);
-      }
-
-      const data = await res.json();
-      if (!data?.url) throw new Error('No portal URL returned');
-      window.location.href = data.url;
-    } catch (e: any) {
-      setErrorMsg(e?.message || 'Could not open customer portal');
-      setLoadingPortal(false);
-    } finally {
-      clearTimeout(t);
-    }
-  }
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-10">
@@ -110,34 +67,7 @@ function AccountPageContent() {
             </div>
           </div>
 
-          {/* Primary shadcn-styled portal button */}
-          <StripePortalButton email={effectiveUser.primaryEmailAddress?.emailAddress || ''} />
-
-          {/* Optional fallback */}
-          <button
-            onClick={openPortalManually}
-            disabled={loadingPortal}
-            className="inline-flex items-center gap-2 rounded-md bg-zinc-900 text-white px-4 py-2 font-medium hover:bg-zinc-800 disabled:opacity-60"
-            aria-label="Open Stripe Customer Portal"
-          >
-            {loadingPortal ? (
-              <>
-                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                Opening portal…
-              </>
-            ) : (
-              'Open Customer Portal'
-            )}
-          </button>
-
-          {errorMsg && (
-            <div
-              role="alert"
-              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300"
-            >
-              {errorMsg}
-            </div>
-          )}
+          <StripePortalButton />
 
           <div className="text-sm text-zinc-600 dark:text-zinc-400">
             Looking to upgrade? See{' '}
@@ -166,8 +96,6 @@ function AccountPageContent() {
 }
 
 export default function AccountPage() {
-  // If auth is disabled (or Clerk publishable key is missing), Clerk hooks will throw.
-  // Render a safe fallback so Next.js can build/prerender.
   if (!isAuthEnabled) {
     return (
       <main className="mx-auto max-w-3xl px-6 py-10">
@@ -192,17 +120,19 @@ export default function AccountPage() {
   }
 
   return (
-    <Suspense fallback={
-      <main className="mx-auto max-w-3xl px-6 py-10">
-        <div className="flex items-center gap-3 mb-2">
-          <h1 className="text-2xl font-bold tracking-tight">Manage Subscription</h1>
-        </div>
-        <p className="text-zinc-600 dark:text-zinc-300 mb-6">
-          Update your plan, billing details, or cancel anytime.
-        </p>
-        <p>Loading…</p>
-      </main>
-    }>
+    <Suspense
+      fallback={
+        <main className="mx-auto max-w-3xl px-6 py-10">
+          <div className="flex items-center gap-3 mb-2">
+            <h1 className="text-2xl font-bold tracking-tight">Manage Subscription</h1>
+          </div>
+          <p className="text-zinc-600 dark:text-zinc-300 mb-6">
+            Update your plan, billing details, or cancel anytime.
+          </p>
+          <p>Loading…</p>
+        </main>
+      }
+    >
       <AccountPageContent />
     </Suspense>
   );

--- a/frontend/app/api/stripe/create-portal-session/route.ts
+++ b/frontend/app/api/stripe/create-portal-session/route.ts
@@ -1,48 +1,13 @@
 import { NextResponse } from 'next/server';
 
-/**
- * Proxies POST /api/stripe/create-portal-session -> BACKEND /stripe/create-portal-session
- * Keeps Preview/Production working without cross-origin CORS issues.
- */
+export const runtime = 'nodejs';
 
-const BACKEND_BASE =
-  (process.env.NEXT_PUBLIC_BACKEND_URL || '').replace(/\/$/, '') || 'http://localhost:8000';
-
-export const runtime = 'nodejs'; // or 'edge' if your backend allows it
-
-export async function POST(req: Request) {
-  try {
-    const body = await req.json().catch(() => ({}));
-    const email = body?.email as string | undefined;
-    if (!email) {
-      return NextResponse.json({ detail: 'Missing email' }, { status: 400 });
-    }
-
-    const res = await fetch(`${BACKEND_BASE}/stripe/create-portal-session`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email }),
-      // Forward cookies/headers only if your backend needs them (Stripe route usually doesn't)
-      // credentials: 'include',
-    });
-
-    // Pass through JSON (or a normalized error)
-    if (!res.ok) {
-      let detail = '';
-      try {
-        detail = (await res.json())?.detail ?? '';
-      } catch {
-        /* ignore */
-      }
-      return NextResponse.json(
-        { detail: detail || `Upstream error (${res.status})` },
-        { status: res.status },
-      );
-    }
-
-    const data = await res.json();
-    return NextResponse.json(data);
-  } catch (e: any) {
-    return NextResponse.json({ detail: e?.message || 'Proxy error' }, { status: 500 });
-  }
+export async function POST() {
+  return NextResponse.json(
+    {
+      detail:
+        'This endpoint is disabled. Use /api/stripe/portal with authenticated user context.',
+    },
+    { status: 410 },
+  );
 }

--- a/frontend/app/api/stripe/portal/route.ts
+++ b/frontend/app/api/stripe/portal/route.ts
@@ -67,12 +67,6 @@ async function getCustomerIdFromUsers(email: string): Promise<string | null> {
   return typeof customer === 'string' && customer.trim() ? customer.trim() : null;
 }
 
-async function getCustomerIdByEmailFallback(stripe: Stripe, email: string): Promise<string | null> {
-  const existing = await stripe.customers.search({ query: `email:'${email}'`, limit: 1 });
-  if (existing.data?.[0]?.id) return existing.data[0].id;
-  return null;
-}
-
 export async function POST() {
   try {
     if (!isClerkServerEnabled()) {
@@ -99,17 +93,11 @@ export async function POST() {
 
     const stripe = new Stripe(KEY, { apiVersion: '2025-09-30.clover' });
 
-    // Source of truth: users.stripe_customer_id (synced by webhook).
-    let customer = await getCustomerIdFromUsers(email);
-
-    // Email fallback is allowed when existing data paths already support it.
-    if (!customer) {
-      customer = await getCustomerIdByEmailFallback(stripe, email);
-    }
+    const customer = await getCustomerIdFromUsers(email);
 
     if (!customer) {
       return NextResponse.json(
-        { ok: false, error: 'No billing account found for your user.' },
+        { ok: false, error: 'No billing account found for your signed-in user.' },
         { status: 404 },
       );
     }

--- a/frontend/app/api/users/plan/route.ts
+++ b/frontend/app/api/users/plan/route.ts
@@ -1,51 +1,76 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { auth, clerkClient } from '@clerk/nextjs/server';
 
-function resolveBackendBase(): string {
-  return (
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getBackendBase(): string {
+  const base = (
     process.env.NEXT_PUBLIC_BACKEND_URL ||
-    process.env.BACKEND_URL ||
     process.env.NEXT_PUBLIC_API_URL ||
+    process.env.BACKEND_URL ||
     process.env.NEXT_PUBLIC_API_BASE ||
-    'http://localhost:8000'
-  ).replace(/\/+$/, '');
+    ''
+  ).trim();
+
+  if (base) return base.replace(/\/+$/, '');
+  if (process.env.NODE_ENV !== 'production') return 'http://localhost:8000';
+  throw new Error('Missing backend base URL env.');
 }
 
-export async function GET(req: NextRequest) {
-  try {
-    const email = req.nextUrl.searchParams.get('email');
-    const upstreamUrl = new URL(`${resolveBackendBase()}/users/plan`);
-    if (email) upstreamUrl.searchParams.set('email', email);
+function isClerkServerEnabled(): boolean {
+  const pk = (process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '').trim();
+  const sk = (process.env.CLERK_SECRET_KEY ?? '').trim();
+  const disable = ['1', 'true', 'yes', 'on'].includes(
+    (process.env.NEXT_PUBLIC_DISABLE_AUTH ?? '').trim().toLowerCase(),
+  );
+  return !disable && pk.startsWith('pk_') && Boolean(sk);
+}
 
-    const authHeader = req.headers.get('authorization');
-    const upstream = await fetch(upstreamUrl.toString(), {
+async function getSignedInUserEmail(): Promise<string | null> {
+  if (!isClerkServerEnabled()) return null;
+
+  const a: any = await auth();
+  const userId = (a?.userId as string | null) ?? null;
+  if (!userId) return null;
+
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  return user.primaryEmailAddress?.emailAddress ?? user.emailAddresses?.[0]?.emailAddress ?? null;
+}
+
+export async function GET() {
+  try {
+    if (!isClerkServerEnabled()) {
+      return NextResponse.json({ detail: 'Authentication is required.' }, { status: 401 });
+    }
+
+    const email = await getSignedInUserEmail();
+    if (!email) {
+      return NextResponse.json({ detail: 'Authentication is required.' }, { status: 401 });
+    }
+
+    const res = await fetch(`${getBackendBase()}/users/plan?email=${encodeURIComponent(email)}`, {
       method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(authHeader ? { Authorization: authHeader } : {}),
-      },
+      headers: { 'Content-Type': 'application/json' },
       cache: 'no-store',
     });
 
-    const upstreamType = (upstream.headers.get('content-type') || '').toLowerCase();
+    const data = await res.json().catch(() => ({}));
 
-    if (!upstream.ok) {
-      if (upstreamType.includes('application/json')) {
-        const errorJson = await upstream.json().catch(() => null as any);
-        const detail = errorJson?.detail || errorJson?.message || errorJson?.error || 'Plan lookup failed';
-        return NextResponse.json({ detail: String(detail) }, { status: upstream.status });
-      }
-      return NextResponse.json({ detail: 'Plan lookup failed' }, { status: upstream.status });
+    if (!res.ok) {
+      return NextResponse.json(
+        { detail: data?.detail || 'Failed to load plan' },
+        { status: res.status },
+      );
     }
 
-    if (!upstreamType.includes('application/json')) {
-      return NextResponse.json({ detail: 'Invalid plan response format' }, { status: 502 });
-    }
-
-    const data = await upstream.json();
-    return NextResponse.json(data, { status: upstream.status });
-  } catch (error) {
+    return NextResponse.json({
+      plan: data?.plan || 'free',
+    });
+  } catch (err: any) {
     return NextResponse.json(
-      { detail: error instanceof Error ? error.message : 'Plan proxy error' },
+      { detail: err?.message || 'Failed to load plan' },
       { status: 500 },
     );
   }

--- a/frontend/app/api/users/plan/route.ts
+++ b/frontend/app/api/users/plan/route.ts
@@ -4,6 +4,19 @@ import { auth, clerkClient } from '@clerk/nextjs/server';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
+type UserPlan = 'free' | 'pro' | 'investor';
+const VALID_PLANS: readonly UserPlan[] = ['free', 'pro', 'investor'];
+
+function parsePlanFromPayload(payload: unknown): UserPlan | null {
+  const rawPlan = (payload as { plan?: unknown } | null)?.plan;
+  if (typeof rawPlan !== 'string') return null;
+  const normalized = rawPlan.trim();
+  if (VALID_PLANS.includes(normalized as UserPlan)) {
+    return normalized as UserPlan;
+  }
+  return null;
+}
+
 function getBackendBase(): string {
   const base = (
     process.env.NEXT_PUBLIC_BACKEND_URL ||
@@ -56,17 +69,27 @@ export async function GET() {
       cache: 'no-store',
     });
 
-    const data = await res.json().catch(() => ({}));
+    const data = await res.json().catch(() => null);
 
     if (!res.ok) {
       return NextResponse.json(
-        { detail: data?.detail || 'Failed to load plan' },
+        {
+          detail:
+            typeof (data as { detail?: unknown } | null)?.detail === 'string'
+              ? (data as { detail: string }).detail
+              : 'Failed to load plan',
+        },
         { status: res.status },
       );
     }
 
+    const plan = parsePlanFromPayload(data);
+    if (!plan) {
+      return NextResponse.json({ detail: 'Invalid plan response format' }, { status: 502 });
+    }
+
     return NextResponse.json({
-      plan: data?.plan || 'free',
+      plan,
     });
   } catch (err: any) {
     return NextResponse.json(

--- a/frontend/components/StripePortalButton.tsx
+++ b/frontend/components/StripePortalButton.tsx
@@ -1,34 +1,32 @@
 'use client';
 
 import { useState } from 'react';
-import { toast } from 'sonner'; // ✅ ensure installed: npm i sonner
+import { toast } from 'sonner';
 
-export default function StripePortalButton({ email }: { email?: string }) {
+export default function StripePortalButton() {
   const [loading, setLoading] = useState(false);
 
   const openPortal = async () => {
-    if (!email) {
-      toast.error('No email found. Please log in first.');
-      return;
-    }
-
     setLoading(true);
+
     try {
-      const res = await fetch('/api/stripe/create-portal-session', {
+      const res = await fetch('/api/stripe/portal', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
       });
 
       const data = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(data?.detail || `HTTP ${res.status}`);
 
-      if (data?.url) {
-        toast.success('Redirecting to billing portal...');
-        window.location.href = data.url;
-      } else {
+      if (!res.ok) {
+        throw new Error(data?.error || data?.detail || `HTTP ${res.status}`);
+      }
+
+      if (!data?.url) {
         throw new Error('No portal URL returned');
       }
+
+      toast.success('Redirecting to billing portal...');
+      window.location.href = data.url;
     } catch (err: any) {
       console.error(err);
       toast.error(err?.message || 'Failed to open customer portal.');
@@ -60,12 +58,12 @@ export default function StripePortalButton({ email }: { email?: string }) {
               r="10"
               stroke="currentColor"
               strokeWidth="4"
-            ></circle>
+            />
             <path
               className="opacity-75"
               fill="currentColor"
               d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-            ></path>
+            />
           </svg>
           Opening...
         </>

--- a/frontend/lib/useUserPlan.ts
+++ b/frontend/lib/useUserPlan.ts
@@ -1,28 +1,14 @@
-"use client";
+'use client';
 
 // frontend/lib/useUserPlan.ts
 import { useEffect, useState, useCallback } from 'react';
 import { useUser } from '@clerk/nextjs';
 import { isAuthEnabled } from '@/lib/auth';
-import { API_BASE } from '@/lib/api';
 
 export type UserPlan = 'free' | 'pro' | 'investor';
 
-type ClerkUser = {
-  primaryEmailAddress?: { emailAddress?: string };
-  emailAddresses?: Array<{ emailAddress?: string }>;
-};
-
-function getClerkUserEmail(user?: ClerkUser | null): string | null {
-  const primary = user?.primaryEmailAddress?.emailAddress;
-  if (primary) return primary;
-  const fallback = user?.emailAddresses?.[0]?.emailAddress;
-  return fallback || null;
-}
-
 export interface UserPlanData {
   plan: UserPlan;
-  stripe_customer_id: string | null;
   loading: boolean;
   error: string | null;
   refetch: () => Promise<void>;
@@ -30,23 +16,10 @@ export interface UserPlanData {
 
 /**
  * Custom hook to fetch and track the current user's subscription plan.
- *
- * Now uses Clerk for authentication:
- * 1. Gets the authenticated user from Clerk
- * 2. Fetches plan details from backend /users/plan endpoint using user email
- * 3. Returns plan, stripe_customer_id, loading state, error, and refetch function
- *
- * Usage:
- *   const { plan, loading, error, refetch } = useUserPlan();
- *   if (loading) return <div>Loading...</div>;
- *   if (plan === 'investor') return <InvestorContent />;
- *
- * After subscription upgrade:
- *   await refetch(); // Manually refresh plan data
+ * Uses authenticated same-origin proxy route instead of exposing email query usage in the browser.
  */
 export function useUserPlan(): UserPlanData {
   const [plan, setPlan] = useState<UserPlan>('free');
-  const [stripeCustomerId, setStripeCustomerId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
@@ -58,66 +31,41 @@ export function useUserPlan(): UserPlanData {
       setLoading(true);
       setError(null);
 
-      // If Clerk isn't enabled, never touch Clerk at all.
       if (!isAuthEnabled) {
         setPlan('free');
-        setStripeCustomerId(null);
         setLoading(false);
         return;
       }
 
-      // Wait for Clerk state to be ready.
       if (!clerkLoaded) {
         return;
       }
 
-      const user = (clerkUser as unknown as ClerkUser | null) ?? null;
-      if (!user) {
+      if (!clerkUser) {
         setPlan('free');
-        setStripeCustomerId(null);
         setLoading(false);
         return;
       }
 
-      const email = getClerkUserEmail(user);
-      if (!email) {
-        console.warn('[useUserPlan] No email found for user');
-        setPlan('free');
-        setStripeCustomerId(null);
-        setLoading(false);
-        return;
-      }
-
-      // Fetch plan from backend using email query parameter
-      const backendUrl = (API_BASE || '').trim();
-      if (!backendUrl) {
-        throw new Error('Missing backend base URL env (NEXT_PUBLIC_API_BASE).');
-      }
-      const response = await fetch(
-        `${backendUrl}/users/plan?email=${encodeURIComponent(email)}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          // Bypass cache to ensure fresh data
-          cache: 'no-store',
-        }
-      );
+      const response = await fetch('/api/users/plan', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-store',
+      });
 
       if (!response.ok) {
         throw new Error(`Failed to fetch plan: ${response.status}`);
       }
 
       const data = await response.json();
-
       setPlan((data.plan as UserPlan) || 'free');
-      setStripeCustomerId(data.stripe_customer_id || null);
       setLoading(false);
     } catch (err: any) {
       console.error('[useUserPlan] Error:', err);
       setError(err.message || 'Failed to fetch user plan');
-      setPlan('free'); // Fallback to free on error
+      setPlan('free');
       setLoading(false);
     }
   }, [clerkLoaded, clerkUser]);
@@ -135,7 +83,6 @@ export function useUserPlan(): UserPlanData {
 
   return {
     plan,
-    stripe_customer_id: stripeCustomerId,
     loading,
     error,
     refetch,


### PR DESCRIPTION
## Summary
- switch account billing action to authenticated `/api/stripe/portal` only
- disable legacy email-based `/api/stripe/create-portal-session` endpoint with HTTP 410
- move browser plan fetch to authenticated same-origin `/api/users/plan` route
- simplify `useUserPlan` to return plan/loading/error/refetch only

## Scope
- applied the requested frontend files exactly (files 1-6)
- intentionally left backend `/users/plan` response shape unchanged in this patch to avoid breaking current portal customer resolution

## Validation
- npm run type-check
- npm run lint
