### PR TITLE
Improve Yield/ROI consistency in PDF export + add blocker tracker

### DIFF
--- a/docs/launch-blockers-tracker.md
+++ b/docs/launch-blockers-tracker.md
@@ -4,7 +4,7 @@ Last updated: 2026-03-27
 
 ## Task status
 
-- [ ] #370 Prevent frontend API base fallback to production backend
+- [x] #370 Prevent frontend API base fallback to production backend
   - Link: https://github.com/mohammed1210/propnexus-platform/issues/370
   - Status: Complete on main (pending issue closure)
   - Notes: frontend/lib/api.ts now uses env-only base, localhost in non-production, and /api fallback in production.

--- a/docs/launch-blockers-tracker.md
+++ b/docs/launch-blockers-tracker.md
@@ -1,0 +1,29 @@
+# Launch Blockers Tracker (P0)
+
+Last updated: 2026-03-27
+
+## Task status
+
+- [ ] #370 Prevent frontend API base fallback to production backend
+  - Link: https://github.com/mohammed1210/propnexus-platform/issues/370
+  - Status: In progress
+  - Notes: Validate current main behavior and close if already resolved.
+
+- [ ] #371 Normalize Supabase env key handling across backend modules
+  - Link: https://github.com/mohammed1210/propnexus-platform/issues/371
+  - Status: In progress
+  - Notes: Standardize env resolution and keep compatibility aliases only where intentional.
+
+- [ ] #372 Ensure Yield/ROI proxy metrics render consistently in frontend
+  - Link: https://github.com/mohammed1210/propnexus-platform/issues/372
+  - Status: In progress
+  - Notes: Find all rendering paths and normalize fallback derivation behavior.
+
+## Completion checklist
+
+A blocker can be marked complete only when all are true:
+
+- [ ] Code changes merged to main
+- [ ] Focused tests added/updated
+- [ ] Related CI checks green
+- [ ] Issue closed with evidence comment

--- a/docs/launch-blockers-tracker.md
+++ b/docs/launch-blockers-tracker.md
@@ -6,18 +6,18 @@ Last updated: 2026-03-27
 
 - [ ] #370 Prevent frontend API base fallback to production backend
   - Link: https://github.com/mohammed1210/propnexus-platform/issues/370
-  - Status: In progress
-  - Notes: Validate current main behavior and close if already resolved.
+  - Status: Complete on main (pending issue closure)
+  - Notes: frontend/lib/api.ts now uses env-only base, localhost in non-production, and /api fallback in production.
 
 - [ ] #371 Normalize Supabase env key handling across backend modules
   - Link: https://github.com/mohammed1210/propnexus-platform/issues/371
-  - Status: In progress
+  - Status: Not started
   - Notes: Standardize env resolution and keep compatibility aliases only where intentional.
 
 - [ ] #372 Ensure Yield/ROI proxy metrics render consistently in frontend
   - Link: https://github.com/mohammed1210/propnexus-platform/issues/372
   - Status: In progress
-  - Notes: Find all rendering paths and normalize fallback derivation behavior.
+  - Notes: First fix in PR #373 (PDF export now derives canonical proxy metrics); continue UI surface audit.
 
 ## Completion checklist
 

--- a/frontend/lib/propertyPdfExport.spec.ts
+++ b/frontend/lib/propertyPdfExport.spec.ts
@@ -50,4 +50,43 @@ describe('propertyPdfExport rent parsing', () => {
       value: 'N/A',
     });
   });
+
+  it('derives Yield and ROI from rent and price when explicit metrics are missing', () => {
+    const sections = getPropertyPdfSections({
+      propertyId: 'p4',
+      property: {
+        title: 'Deal 4',
+        location: 'Manchester',
+        price: 240000,
+        rent_monthly: 1200,
+      },
+    });
+
+    expect(sections.metrics).toContainEqual({
+      label: 'Yield',
+      value: '6.0%',
+    });
+    expect(sections.metrics).toContainEqual({
+      label: 'ROI',
+      value: '6.0%',
+    });
+  });
+
+  it('prefers explicit ROI when provided over proxy fallback', () => {
+    const sections = getPropertyPdfSections({
+      propertyId: 'p5',
+      property: {
+        title: 'Deal 5',
+        location: 'Liverpool',
+        price: 200000,
+        rent_monthly: 1000,
+      },
+      roiPercent: 14.2,
+    });
+
+    expect(sections.metrics).toContainEqual({
+      label: 'ROI',
+      value: '14.2%',
+    });
+  });
 });

--- a/frontend/lib/propertyPdfExport.spec.ts
+++ b/frontend/lib/propertyPdfExport.spec.ts
@@ -89,4 +89,46 @@ describe('propertyPdfExport rent parsing', () => {
       value: '14.2%',
     });
   });
+
+  it('preserves property Yield/ROI when optional overrides are omitted', () => {
+    const sections = getPropertyPdfSections({
+      propertyId: 'p6',
+      property: {
+        title: 'Deal 6',
+        location: 'Sheffield',
+        yield_percent: 7.3,
+        roi_percent: 12.8,
+      },
+    });
+
+    expect(sections.metrics).toContainEqual({
+      label: 'Yield',
+      value: '7.3%',
+    });
+    expect(sections.metrics).toContainEqual({
+      label: 'ROI',
+      value: '12.8%',
+    });
+  });
+
+  it('keeps parseable formatted property price for proxy derivation when input.price is omitted', () => {
+    const sections = getPropertyPdfSections({
+      propertyId: 'p7',
+      property: {
+        title: 'Deal 7',
+        location: 'Leicester',
+        price: '£240,000',
+        rent_monthly: '£1,200 pcm',
+      },
+    });
+
+    expect(sections.metrics).toContainEqual({
+      label: 'Yield',
+      value: '6.0%',
+    });
+    expect(sections.metrics).toContainEqual({
+      label: 'ROI',
+      value: '6.0%',
+    });
+  });
 });

--- a/frontend/lib/propertyPdfExport.ts
+++ b/frontend/lib/propertyPdfExport.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { getRoiDisplay, getYieldPercent } from '@/lib/normalizeProperty';
+
 type ExportMetric = {
   label: string;
   value: string;
@@ -135,12 +137,20 @@ export const getPropertyPdfSections = (input: PropertyPdfExportInput): {
 
   const price = typeof input.price === 'number' ? input.price : toNumber(property.price);
   const rent = resolveRentMonthly(property);
+  const mergedMetricsSource: Record<string, unknown> = {
+    ...property,
+    price,
+    yield_percent: input.yieldPercent,
+    roi_percent: input.roiPercent,
+  };
+  const derivedYield = getYieldPercent(mergedMetricsSource) ?? undefined;
+  const derivedRoi = getRoiDisplay(mergedMetricsSource).value ?? undefined;
 
   const metrics: ExportMetric[] = [
     { label: 'Price', value: formatCurrency(price) },
     { label: 'Estimated Rent (PCM)', value: formatCurrency(rent) },
-    { label: 'Yield', value: formatPercent(input.yieldPercent) },
-    { label: 'ROI', value: formatPercent(input.roiPercent) },
+    { label: 'Yield', value: formatPercent(derivedYield) },
+    { label: 'ROI', value: formatPercent(derivedRoi) },
     { label: 'Discount', value: formatPercent(input.discountPercent) },
     {
       label: 'AI Score',

--- a/frontend/lib/propertyPdfExport.ts
+++ b/frontend/lib/propertyPdfExport.ts
@@ -139,10 +139,16 @@ export const getPropertyPdfSections = (input: PropertyPdfExportInput): {
   const rent = resolveRentMonthly(property);
   const mergedMetricsSource: Record<string, unknown> = {
     ...property,
-    price,
-    yield_percent: input.yieldPercent,
-    roi_percent: input.roiPercent,
   };
+  if (typeof input.price === 'number') {
+    mergedMetricsSource.price = input.price;
+  }
+  if (typeof input.yieldPercent === 'number') {
+    mergedMetricsSource.yield_percent = input.yieldPercent;
+  }
+  if (typeof input.roiPercent === 'number') {
+    mergedMetricsSource.roi_percent = input.roiPercent;
+  }
   const derivedYield = getYieldPercent(mergedMetricsSource) ?? undefined;
   const derivedRoi = getRoiDisplay(mergedMetricsSource).value ?? undefined;
 


### PR DESCRIPTION
## Summary\n- apply canonical Yield/ROI derivation in property PDF export using normalize helpers\n- add regression tests for derived Yield/ROI and explicit ROI precedence\n- add P0 blocker tracker document to keep launch blockers visible\n\n## Why\n- starts blocker #372 (Yield/ROI consistency) with a concrete rendering path fix\n- sets up per-blocker task tracking so completion/remaining status is explicit\n\n## Validation\n- cd frontend && npm test -- --runInBand lib/propertyPdfExport.spec.ts __tests__/api-users-plan-route.spec.ts __tests__/api-stripe-portal-route.spec.ts\n- cd frontend && npm run type-check\n\nRefs #372