### PR TITLE
Normalize Supabase key env resolution with legacy aliases

### DIFF
--- a/backend/tests/test_health_supabase_flag.py
+++ b/backend/tests/test_health_supabase_flag.py
@@ -45,3 +45,24 @@ def test_health_includes_supabase_configured_boolean(monkeypatch: pytest.MonkeyP
     body2 = resp2.json()
     assert body2.get("supabase_configured") is True
     assert secret_key not in resp2.text
+
+
+def test_health_accepts_legacy_service_key_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    if app is None:  # pragma: no cover
+        pytest.skip(f"App unavailable in CI: {_import_error}")
+
+    client = TestClient(app)
+
+    monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "legacy-service-key")
+    resp_service_key = client.get("/health")
+    assert resp_service_key.status_code == 200
+    assert resp_service_key.json().get("supabase_configured") is True
+
+    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+    monkeypatch.setenv("SUPABASE_KEY", "legacy-generic-key")
+    resp_generic_key = client.get("/health")
+    assert resp_generic_key.status_code == 200
+    assert resp_generic_key.json().get("supabase_configured") is True

--- a/backend/tests/test_health_supabase_flag.py
+++ b/backend/tests/test_health_supabase_flag.py
@@ -55,6 +55,7 @@ def test_health_accepts_legacy_service_key_aliases(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
     monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    monkeypatch.delenv("SUPABASE_KEY", raising=False)
 
     monkeypatch.setenv("SUPABASE_SERVICE_KEY", "legacy-service-key")
     resp_service_key = client.get("/health")

--- a/backend/utils/supabase_env.py
+++ b/backend/utils/supabase_env.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+SERVICE_ROLE_KEY_ENV_ORDER: tuple[str, ...] = (
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPABASE_SERVICE_KEY",
+    "SUPABASE_KEY",
+)
+
 
 @dataclass(frozen=True)
 class SupabaseConfig:
@@ -39,17 +45,25 @@ def _getenv_stripped(name: str) -> str | None:
     return value or None
 
 
+def _get_first_non_empty(names: tuple[str, ...]) -> str | None:
+    for name in names:
+        value = _getenv_stripped(name)
+        if value:
+            return value
+    return None
+
+
 def resolve_supabase_env_block() -> SupabaseEnvBlock:
     """Read the canonical backend Supabase env block.
 
     Required vars:
     - SUPABASE_URL
-    - SUPABASE_SERVICE_ROLE_KEY
+    - SUPABASE_SERVICE_ROLE_KEY (preferred; legacy aliases are accepted)
     """
 
     return SupabaseEnvBlock(
         url=_getenv_stripped("SUPABASE_URL"),
-        service_role_key=_getenv_stripped("SUPABASE_SERVICE_ROLE_KEY"),
+        service_role_key=_get_first_non_empty(SERVICE_ROLE_KEY_ENV_ORDER),
     )
 
 


### PR DESCRIPTION
## Summary\n- normalize backend Supabase key lookup to prefer SUPABASE_SERVICE_ROLE_KEY\n- support legacy aliases SUPABASE_SERVICE_KEY and SUPABASE_KEY for compatibility\n- add regression coverage on /health supabase_configured behavior for alias keys\n\n## Why\n- addresses blocker #371 by ensuring consistent Supabase config detection across modules and env naming variants\n\n## Validation\n- /workspaces/propnexus-platform/.venv/bin/python -m pytest /workspaces/propnexus-platform/backend/tests/test_health_supabase_flag.py -q\n\nRefs #371