### PR TITLE
Add evidence-backed investor deal labels

### DIFF
--- a/frontend/app/property/[id]/page.tsx
+++ b/frontend/app/property/[id]/page.tsx
@@ -16,6 +16,7 @@ import QuickStatsActions from '@/components/property_details/QuickStatsActions';
 import InvestmentSummary from '@/components/property_details/InvestmentSummary';
 import ExitStrategyGenerator from '@/components/property_details/ExitStrategyGenerator';
 import DealScore from '@/components/property_details/DealScore';
+import DealLabelPanel from '@/components/property_details/DealLabelPanel';
 import AreaInsights from '@/components/property_details/AreaInsights';
 import GatedPanel from '@/components/property_details/GatedPanel';
 import InvestmentCalculator from '@/components/property_details/InvestmentCalculator';
@@ -289,6 +290,22 @@ export default function PropertyDetailsPage() {
     return typeof d === 'string' ? d.trim() : '';
   }, [property]);
 
+  const dealLabelProperty = useMemo(() => {
+    if (!property) return null;
+    const listingHistory = (investorIntel as any)?.listing_history ?? null;
+    return {
+      ...(property as any),
+      sold_comp_benchmark:
+        (investorIntel as any)?.sold_comp_benchmark
+        ?? (property as any)?.sold_comp_benchmark
+        ?? (property as any)?.comps?.sales_benchmark
+        ?? null,
+      rental_evidence: (investorIntel as any)?.rental_evidence ?? (property as any)?.rental_evidence ?? null,
+      listing_history: listingHistory,
+      price_history: listingHistory?.price_history ?? (property as any)?.price_history ?? null,
+    };
+  }, [investorIntel, property]);
+
   if (loading) {
     return (
       <div className="page-wrapper">
@@ -439,6 +456,8 @@ export default function PropertyDetailsPage() {
           <PropertyDescription brief={investmentDescription} />
           <WhySurfaced property={property as any} />
         </div>
+
+        {dealLabelProperty ? <DealLabelPanel property={dealLabelProperty as any} className="mb-6" /> : null}
 
         <InfoDisclaimer className="mb-6" label="Investor brief disclaimer">
           Investor brief and scores are indicative only. Verify rent, comparable sales, finance, works, legal pack and tax position before making an offer. {INVESTMENT_DISCLAIMER_SHORT}

--- a/frontend/components/PropertyCard.tsx
+++ b/frontend/components/PropertyCard.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/lib/normalizeProperty';
 import { Badge } from '@/components/Badges';
 import MetricExplainer from '@/components/property_details/MetricExplainer';
+import DealLabelChip from '@/components/property_details/DealLabelChip';
 import { getTopDealDisplay, isProminentDealFinder, shouldShowDealFinderOnCard } from '@/lib/topDealCopy';
 
 // tiny classnames helper – keeps conditional class logic tidy
@@ -403,6 +404,19 @@ export default function PropertyCard({
     void timeTick;
     return out;
   }, [insights, normalized.yieldPercent, p.monthly_rent, p.price, p.rent, p.rent_pcm, p.rent_per_month, timeTick]);
+
+  const dealLabelProperty = useMemo(
+    () => ({
+      ...(p as any),
+      derived,
+      displayYieldPct,
+      rentMonthly: derived.rentMonthly,
+      grossYieldPct: derived.grossYieldPct,
+      compsMedianSold: derived.compsMedianSold,
+      compsCount: derived.compsCount,
+    }),
+    [derived, displayYieldPct, p],
+  );
 
   function median(nums: number[]): number {
     const a = [...nums].sort((x, y) => x - y);
@@ -787,6 +801,8 @@ export default function PropertyCard({
             ))}
           </div>
         )}
+
+        <DealLabelChip property={dealLabelProperty} />
 
         {showDealFinder && prominentDealFinder && topDeal && (
           <div className={cx(

--- a/frontend/components/__tests__/dealLabel.spec.tsx
+++ b/frontend/components/__tests__/dealLabel.spec.tsx
@@ -1,0 +1,129 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import DealLabelChip from '../property_details/DealLabelChip';
+import DealLabelExplainer from '../property_details/DealLabelExplainer';
+import DealLabelPanel from '../property_details/DealLabelPanel';
+import { computeDealLabel } from '@/lib/dealLabel';
+
+const strongEvidenceProperty = {
+  title: 'Chain-free auction house with renovation scope',
+  description: 'No onward chain. Guide price with scope to improve and loft conversion STPP.',
+  price: 200000,
+  sold_comp_benchmark: { median_price: 255000 },
+  comps_count: 5,
+  monthly_rent: 1400,
+  previous_price: 230000,
+  postcode: 'M14 5AA',
+  source_url: 'https://example.com/listing/1',
+  image_urls: ['one.jpg', 'two.jpg', 'three.jpg'],
+};
+
+describe('computeDealLabel', () => {
+  it('scores an evidence-backed opportunity as Prime Deal or Strong Deal', () => {
+    const result = computeDealLabel(strongEvidenceProperty);
+
+    expect(['prime_deal', 'strong_deal']).toContain(result.code);
+    expect(result.score).toBeGreaterThanOrEqual(68);
+    expect(result.confidence).toBeGreaterThanOrEqual(40);
+    expect(result.calculations.priceDiscountPct).toBeGreaterThanOrEqual(7);
+    expect(result.calculations.rentEvidence).toBe('direct');
+  });
+
+  it('does not label a listing with no comps or rent as a good deal', () => {
+    const result = computeDealLabel({
+      title: 'Flat with limited listing data',
+      price: 180000,
+      postcode: 'SE1 1AA',
+      image_urls: ['one.jpg'],
+    });
+
+    expect(['prime_deal', 'strong_deal']).not.toContain(result.code);
+    expect(result.confidence).toBeLessThan(40);
+    expect(result.mainRisks).toEqual(expect.arrayContaining(['Missing comps and rent evidence']));
+  });
+
+  it('penalises an overpriced listing against benchmark', () => {
+    const result = computeDealLabel({
+      price: 330000,
+      sold_comp_benchmark: 280000,
+      monthly_rent: 900,
+      comps_count: 4,
+      postcode: 'LS1 2AB',
+      source_url: 'https://example.com/listing/2',
+      image_urls: ['one.jpg', 'two.jpg', 'three.jpg'],
+    });
+
+    expect(result.pricePositionLabel).toMatch(/above sold benchmark/i);
+    expect(result.calculations.penalties).toEqual(expect.arrayContaining([expect.objectContaining({ label: 'More than 10% above benchmark' })]));
+    expect(['prime_deal', 'strong_deal']).not.toContain(result.code);
+  });
+
+  it('shows price reduction and listing signal breakdowns', () => {
+    const result = computeDealLabel(strongEvidenceProperty);
+    const reductionSignal = result.signals.find((signal) => signal.key === 'price_reduction');
+    const listingSignal = result.signals.find((signal) => signal.key === 'listing_signals');
+
+    expect(result.calculations.priceReductionPct).toBeGreaterThanOrEqual(10);
+    expect(reductionSignal?.points).toBeGreaterThanOrEqual(10);
+    expect(listingSignal?.detail).toMatch(/Chain-free|Auction|Value-add|Extension/i);
+  });
+
+  it('normalizes weekly and annual rent strings before calculating yield', () => {
+    const weeklyRent = computeDealLabel({
+      price: 300000,
+      sold_comp_benchmark: 310000,
+      rent: '£400 pw',
+      comps_count: 4,
+      postcode: 'E8 1AA',
+      source_url: 'https://example.com/listing/3',
+      image_urls: ['one.jpg', 'two.jpg', 'three.jpg'],
+    });
+    const annualRent = computeDealLabel({
+      price: 300000,
+      sold_comp_benchmark: 310000,
+      rent: '£18,000 pa',
+      comps_count: 4,
+      postcode: 'E8 1AA',
+      source_url: 'https://example.com/listing/4',
+      image_urls: ['one.jpg', 'two.jpg', 'three.jpg'],
+    });
+
+    expect(weeklyRent.calculations.monthlyRent).toBeCloseTo(1733.33, 1);
+    expect(weeklyRent.calculations.grossYieldPct).toBeCloseTo(6.93, 1);
+    expect(annualRent.calculations.monthlyRent).toBe(1500);
+    expect(annualRent.calculations.grossYieldPct).toBeCloseTo(6, 1);
+  });
+});
+
+describe('Deal label components', () => {
+  it('renders the compact card chip', () => {
+    render(<DealLabelChip property={strongEvidenceProperty} />);
+
+    expect(screen.getByTestId('deal-label-chip')).toBeInTheDocument();
+    expect(screen.getByText('Investor Deal Label')).toBeInTheDocument();
+    expect(screen.getByText(/Deal$/)).toBeInTheDocument();
+    expect(screen.getByText(/\/100/)).toBeInTheDocument();
+  });
+
+  it('renders the detail panel breakdown', () => {
+    render(<DealLabelPanel property={strongEvidenceProperty} />);
+
+    expect(screen.getByTestId('deal-label-panel')).toBeInTheDocument();
+    expect(screen.getByText('Why this label?')).toBeInTheDocument();
+    expect(screen.getByText('Main checks before offer')).toBeInTheDocument();
+    expect(screen.getByText('Signal breakdown')).toBeInTheDocument();
+    expect(screen.getByText(/not formal valuations/i)).toBeInTheDocument();
+  });
+
+  it('opens the explainer modal', () => {
+    render(<DealLabelExplainer />);
+
+    fireEvent.click(screen.getByRole('button', { name: /explain investor deal labels/i }));
+
+    expect(screen.getByRole('dialog', { name: /how propnexus deal labels work/i })).toBeInTheDocument();
+    expect(screen.getByText('Prime Deal')).toBeInTheDocument();
+    expect(screen.getByText('Evidence Needed')).toBeInTheDocument();
+    expect(screen.getByText(/asking price/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/property_details/DealLabelChip.tsx
+++ b/frontend/components/property_details/DealLabelChip.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useMemo } from 'react';
+import { FiShield, FiTrendingUp } from 'react-icons/fi';
+import { computeDealLabel, type DealLabelTone } from '@/lib/dealLabel';
+import DealLabelExplainer from './DealLabelExplainer';
+
+type Props = {
+  property: Record<string, any>;
+  className?: string;
+};
+
+function toneClasses(tone: DealLabelTone): string {
+  if (tone === 'emerald') return 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-300/25 dark:bg-emerald-400/10 dark:text-emerald-100';
+  if (tone === 'blue') return 'border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-300/25 dark:bg-blue-400/10 dark:text-blue-100';
+  if (tone === 'amber') return 'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-300/25 dark:bg-amber-400/10 dark:text-amber-100';
+  if (tone === 'rose') return 'border-rose-200 bg-rose-50 text-rose-900 dark:border-rose-300/25 dark:bg-rose-400/10 dark:text-rose-100';
+  return 'border-slate-200 bg-slate-50 text-slate-800 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100';
+}
+
+export default function DealLabelChip({ property, className = '' }: Props) {
+  const dealLabel = useMemo(() => computeDealLabel(property), [property]);
+
+  return (
+    <div className={`rounded-2xl border px-3 py-2 shadow-sm ${toneClasses(dealLabel.tone)} ${className}`} data-testid="deal-label-chip">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5 text-[9px] font-black uppercase tracking-[0.18em] opacity-80">
+            <FiShield className="h-3 w-3" aria-hidden="true" />
+            Investor Deal Label
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <span className="text-sm font-black leading-none">{dealLabel.label}</span>
+            <span className="inline-flex items-center gap-1 rounded-full bg-white/70 px-2 py-0.5 text-[10px] font-black text-slate-800 dark:bg-slate-950/40 dark:text-white">
+              <FiTrendingUp className="h-3 w-3" aria-hidden="true" />
+              {dealLabel.score}/100
+            </span>
+          </div>
+          <p className="mt-1 text-[11px] font-semibold leading-snug opacity-85">{dealLabel.shortReason}</p>
+        </div>
+        <DealLabelExplainer compact />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/property_details/DealLabelExplainer.tsx
+++ b/frontend/components/property_details/DealLabelExplainer.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useId, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { FiInfo, FiX } from 'react-icons/fi';
+import { getDealLabelLegalCopy } from '@/lib/dealLabel';
+
+type Props = {
+  compact?: boolean;
+  className?: string;
+};
+
+const labels = [
+  { name: 'Prime Deal', copy: 'High score, usable confidence and a strong value signal such as a meaningful discount or strong yield.' },
+  { name: 'Strong Deal', copy: 'Good evidence-backed score with at least one strong value signal, but still needs normal diligence.' },
+  { name: 'Fair Deal', copy: 'Some evidence supports the case, but the edge is not strong enough for a premium label.' },
+  { name: 'Needs Review', copy: 'Promising or incomplete signals require manual checks before treating it as investable.' },
+  { name: 'High Risk', copy: 'Weak evidence, poor pricing, low yield or specialist-risk wording means extra caution is needed.' },
+  { name: 'Evidence Needed', copy: 'Confidence is too low because key evidence such as price, rent or comparable sales is missing.' },
+];
+
+const dataUsed = [
+  'asking price',
+  'nearby sold prices',
+  'rent evidence',
+  'yield',
+  'price reductions',
+  'chain-free, auction and value-add wording',
+  'data quality',
+];
+
+export default function DealLabelExplainer({ compact = false, className = '' }: Props) {
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open]);
+
+  const modal = open && typeof document !== 'undefined'
+    ? createPortal(
+        <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-slate-950/55 px-4 py-6 backdrop-blur-sm" role="presentation">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border border-slate-200 bg-white p-5 text-slate-800 shadow-2xl dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 sm:p-6"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-brand-600 dark:text-brand-300">
+                  Investor Deal Label
+                </div>
+                <h2 id={titleId} className="mt-1 text-xl font-black tracking-tight text-slate-950 dark:text-white">
+                  How PropNexus deal labels work
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:bg-slate-50 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-900 dark:hover:text-white"
+                aria-label="Close deal label explainer"
+              >
+                <FiX className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+
+            <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+              PropNexus labels are evidence-backed investor readouts. They are separate from the AI Deal Score and use available listing, rent and comparable-market evidence rather than a fixed or hardcoded label.
+            </p>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-2">
+              {labels.map((item) => (
+                <div key={item.name} className="rounded-xl border border-slate-200 bg-slate-50/70 p-3 dark:border-slate-800 dark:bg-slate-900/40">
+                  <div className="text-sm font-black text-slate-950 dark:text-white">{item.name}</div>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-300">{item.copy}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-5 rounded-xl border border-brand-100 bg-brand-50/60 p-4 dark:border-brand-900/50 dark:bg-brand-950/20">
+              <div className="text-sm font-black text-slate-950 dark:text-white">Data used</div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {dataUsed.map((item) => (
+                  <span key={item} className="rounded-full border border-white/80 bg-white px-2.5 py-1 text-xs font-semibold text-slate-700 shadow-sm dark:border-white/10 dark:bg-slate-950/70 dark:text-slate-200">
+                    {item}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <p className="mt-5 rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs leading-relaxed text-amber-900 dark:border-amber-300/25 dark:bg-amber-400/10 dark:text-amber-100">
+              {getDealLabelLegalCopy()}
+            </p>
+          </div>
+        </div>,
+        document.body,
+      )
+    : null;
+
+  return (
+    <span className={`inline-flex items-center ${className}`}>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={compact
+          ? 'inline-flex h-6 w-6 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white'
+          : 'inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-bold text-slate-700 shadow-sm transition hover:border-brand-200 hover:text-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-brand-700 dark:hover:text-brand-200'}
+        aria-label="Explain investor deal labels"
+      >
+        <FiInfo className="h-3.5 w-3.5" aria-hidden="true" />
+        {compact ? null : <span>How labels work</span>}
+      </button>
+      {modal}
+    </span>
+  );
+}

--- a/frontend/components/property_details/DealLabelPanel.tsx
+++ b/frontend/components/property_details/DealLabelPanel.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useMemo } from 'react';
+import { FiAlertTriangle, FiCheckCircle, FiShield, FiTrendingUp } from 'react-icons/fi';
+import {
+  computeDealLabel,
+  formatMoney,
+  formatPct,
+  getDealLabelLegalCopy,
+  type DealLabelTone,
+} from '@/lib/dealLabel';
+import DealLabelExplainer from './DealLabelExplainer';
+
+type Props = {
+  property: Record<string, any>;
+  className?: string;
+};
+
+function toneClasses(tone: DealLabelTone): string {
+  if (tone === 'emerald') return 'border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-300/25 dark:bg-emerald-400/10 dark:text-emerald-100';
+  if (tone === 'blue') return 'border-blue-200 bg-blue-50 text-blue-800 dark:border-blue-300/25 dark:bg-blue-400/10 dark:text-blue-100';
+  if (tone === 'amber') return 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-300/25 dark:bg-amber-400/10 dark:text-amber-100';
+  if (tone === 'rose') return 'border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-300/25 dark:bg-rose-400/10 dark:text-rose-100';
+  return 'border-slate-200 bg-slate-50 text-slate-800 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100';
+}
+
+function barClass(tone: DealLabelTone): string {
+  if (tone === 'emerald') return 'from-emerald-400 to-lime-300';
+  if (tone === 'blue') return 'from-blue-400 to-cyan-300';
+  if (tone === 'amber') return 'from-amber-400 to-orange-300';
+  if (tone === 'rose') return 'from-rose-400 to-red-300';
+  return 'from-slate-300 to-slate-500';
+}
+
+export default function DealLabelPanel({ property, className = '' }: Props) {
+  const dealLabel = useMemo(() => computeDealLabel(property), [property]);
+  const calculations = dealLabel.calculations;
+
+  const workedOut = [
+    `Price position: ${dealLabel.pricePositionLabel}`,
+    `Rent evidence: ${calculations.rentEvidence === 'direct' ? 'direct property evidence' : calculations.rentEvidence === 'derived' ? 'derived evidence' : 'missing'}`,
+    `Comparable sales: ${calculations.soldBenchmark ? formatMoney(calculations.soldBenchmark) : 'not available'}${calculations.compsCount !== null ? ` from ${calculations.compsCount} comps` : ''}`,
+    `Listing signals: ${calculations.positiveListingSignals.length ? calculations.positiveListingSignals.join(', ') : 'none found'}`,
+  ];
+
+  return (
+    <section className={`overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950/40 ${className}`} data-testid="deal-label-panel">
+      <div className="border-b border-slate-200 bg-gradient-to-br from-slate-50 via-white to-brand-50/50 p-5 dark:border-slate-800 dark:from-slate-950 dark:via-slate-950 dark:to-brand-950/20 sm:p-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-[0.18em] text-brand-700 dark:text-brand-200">
+                <FiShield className="h-4 w-4" aria-hidden="true" />
+                Investor Deal Label
+              </div>
+              <DealLabelExplainer />
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-3">
+              <span className={`inline-flex items-center rounded-full border px-3 py-1 text-sm font-black ${toneClasses(dealLabel.tone)}`}>
+                {dealLabel.label}
+              </span>
+              <span className="text-sm font-bold text-slate-600 dark:text-slate-300">Score {dealLabel.score}/100</span>
+              <span className="text-sm font-bold text-slate-600 dark:text-slate-300">Confidence {dealLabel.confidence}/100</span>
+            </div>
+            <h2 className="mt-4 text-2xl font-black tracking-tight text-slate-950 dark:text-white">
+              {dealLabel.pricePositionLabel}
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+              {dealLabel.summary}
+            </p>
+          </div>
+          <div className="grid min-w-[220px] grid-cols-2 gap-2 rounded-2xl border border-white/70 bg-white/80 p-3 shadow-sm dark:border-white/10 dark:bg-slate-950/50">
+            <div>
+              <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">Score</div>
+              <div className="mt-1 text-2xl font-black text-slate-950 dark:text-white">{dealLabel.score}</div>
+            </div>
+            <div>
+              <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">Confidence</div>
+              <div className="mt-1 text-2xl font-black text-slate-950 dark:text-white">{dealLabel.confidence}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-6 p-5 sm:p-6">
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <div className="rounded-xl border border-slate-200 bg-slate-50/70 p-3 dark:border-slate-800 dark:bg-slate-900/30">
+            <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">Asking price</div>
+            <div className="mt-1 text-lg font-black text-slate-950 dark:text-white">{formatMoney(calculations.askingPrice)}</div>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-slate-50/70 p-3 dark:border-slate-800 dark:bg-slate-900/30">
+            <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">Sold benchmark</div>
+            <div className="mt-1 text-lg font-black text-slate-950 dark:text-white">{formatMoney(calculations.soldBenchmark)}</div>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-slate-50/70 p-3 dark:border-slate-800 dark:bg-slate-900/30">
+            <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">Gross yield</div>
+            <div className="mt-1 text-lg font-black text-slate-950 dark:text-white">{formatPct(calculations.grossYieldPct)}</div>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-slate-50/70 p-3 dark:border-slate-800 dark:bg-slate-900/30">
+            <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">Monthly rent</div>
+            <div className="mt-1 text-lg font-black text-slate-950 dark:text-white">{formatMoney(calculations.monthlyRent)}</div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-950/30">
+            <div className="flex items-center gap-2 text-sm font-black text-slate-950 dark:text-white">
+              <FiCheckCircle className="h-4 w-4 text-emerald-500" aria-hidden="true" />
+              Why this label?
+            </div>
+            <ul className="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-300">
+              {dealLabel.strongestSignals.map((signal) => (
+                <li key={signal} className="leading-relaxed">{signal}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-950/30">
+            <div className="flex items-center gap-2 text-sm font-black text-slate-950 dark:text-white">
+              <FiAlertTriangle className="h-4 w-4 text-amber-500" aria-hidden="true" />
+              Main checks before offer
+            </div>
+            <ul className="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-300">
+              {dealLabel.mainRisks.map((risk) => (
+                <li key={risk} className="leading-relaxed">{risk}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center gap-2 text-sm font-black text-slate-950 dark:text-white">
+            <FiTrendingUp className="h-4 w-4 text-brand-500" aria-hidden="true" />
+            How we worked it out
+          </div>
+          <div className="mt-3 grid gap-3 lg:grid-cols-2">
+            {workedOut.map((item) => (
+              <div key={item} className="rounded-xl border border-slate-200 bg-slate-50/70 p-3 text-sm font-semibold text-slate-700 dark:border-slate-800 dark:bg-slate-900/30 dark:text-slate-300">
+                {item}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <div className="text-sm font-black text-slate-950 dark:text-white">Signal breakdown</div>
+          <div className="mt-3 grid gap-3 lg:grid-cols-2">
+            {dealLabel.signals.map((signal) => {
+              const width = Math.max(0, Math.min(100, (signal.points / signal.max) * 100));
+              return (
+                <div key={signal.key} className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-950/30">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-black text-slate-950 dark:text-white">{signal.label}</div>
+                      <p className="mt-1 text-xs leading-relaxed text-slate-500 dark:text-slate-400">{signal.detail}</p>
+                    </div>
+                    <div className="shrink-0 text-sm font-black text-slate-800 dark:text-slate-100">{signal.points}/{signal.max}</div>
+                  </div>
+                  <div className="mt-3 h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-white/10" aria-hidden="true">
+                    <div className={`h-full rounded-full bg-gradient-to-r ${barClass(signal.tone)}`} style={{ width: `${width}%` }} />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <p className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs leading-relaxed text-amber-900 dark:border-amber-300/25 dark:bg-amber-400/10 dark:text-amber-100">
+          {getDealLabelLegalCopy()}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/lib/dealLabel.ts
+++ b/frontend/lib/dealLabel.ts
@@ -1,0 +1,430 @@
+import { parseRent } from '@/lib/normalizeProperty';
+
+export type DealLabelCode =
+  | 'prime_deal'
+  | 'strong_deal'
+  | 'fair_deal'
+  | 'needs_review'
+  | 'high_risk'
+  | 'insufficient_evidence';
+
+export type DealLabelTone = 'emerald' | 'blue' | 'amber' | 'rose' | 'slate';
+
+export type DealLabelSignal = {
+  key: string;
+  label: string;
+  points: number;
+  max: number;
+  tone: DealLabelTone;
+  detail: string;
+};
+
+export type DealLabelResult = {
+  code: DealLabelCode;
+  label: string;
+  score: number;
+  confidence: number;
+  tone: DealLabelTone;
+  summary: string;
+  shortReason: string;
+  pricePositionLabel: string;
+  strongestSignals: string[];
+  mainRisks: string[];
+  signals: DealLabelSignal[];
+  calculations: {
+    askingPrice: number | null;
+    soldBenchmark: number | null;
+    soldBenchmarkSource: string | null;
+    priceDiscountPct: number | null;
+    grossYieldPct: number | null;
+    monthlyRent: number | null;
+    rentEvidence: 'direct' | 'derived' | 'missing';
+    priceReductionPct: number | null;
+    compsCount: number | null;
+    imagesCount: number;
+    positiveListingSignals: string[];
+    riskListingSignals: string[];
+    dataQualityPoints: number;
+    penalties: Array<{ label: string; points: number }>;
+  };
+};
+
+const LABELS: Record<DealLabelCode, { label: string; tone: DealLabelTone }> = {
+  prime_deal: { label: 'Prime Deal', tone: 'emerald' },
+  strong_deal: { label: 'Strong Deal', tone: 'blue' },
+  fair_deal: { label: 'Fair Deal', tone: 'amber' },
+  needs_review: { label: 'Needs Review', tone: 'amber' },
+  high_risk: { label: 'High Risk', tone: 'rose' },
+  insufficient_evidence: { label: 'Evidence Needed', tone: 'slate' },
+};
+
+const POSITIVE_SIGNAL_PATTERNS: Array<{ label: string; pattern: RegExp; points: number }> = [
+  { label: 'Chain-free or vacant possession', pattern: /chain\s*free|no onward chain|vacant possession/i, points: 3 },
+  { label: 'Auction or motivated pricing language', pattern: /auction|guide price|offers over|oieo|motivated seller|priced to sell/i, points: 3 },
+  { label: 'Value-add or refurbishment wording', pattern: /refurb|renovat|modernis|\btlc\b|project|value[-\s]?add|scope to improve/i, points: 3 },
+  { label: 'Extension or planning upside', pattern: /extension|planning|loft conversion|\bstpp\b/i, points: 2 },
+];
+
+const RISK_SIGNAL_PATTERNS: Array<{ label: string; pattern: RegExp; points: number }> = [
+  { label: 'Cash buyer only', pattern: /cash buyer only|cash buyers only/i, points: 4 },
+  { label: 'Short lease', pattern: /short lease/i, points: 4 },
+  { label: 'Unmortgageable', pattern: /unmortgageable/i, points: 5 },
+  { label: 'Structural issue', pattern: /structural|subsidence/i, points: 5 },
+  { label: 'Legal pack risk', pattern: /legal pack risk|legal pack/i, points: 3 },
+];
+
+function clamp(value: number, min = 0, max = 100): number {
+  return Math.max(min, Math.min(max, Number.isFinite(value) ? value : min));
+}
+
+function cleanNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) && value > 0 ? value : null;
+  if (typeof value === 'string') {
+    const cleaned = value.replace(/[^0-9.\-]/g, '');
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+  return null;
+}
+
+function getPath(source: any, path: string): unknown {
+  return path.split('.').reduce((acc, key) => (acc && typeof acc === 'object' ? acc[key] : undefined), source);
+}
+
+function firstNumber(source: any, paths: string[]): number | null {
+  for (const path of paths) {
+    const value = cleanNumber(getPath(source, path));
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function firstString(source: any, paths: string[]): string | null {
+  for (const path of paths) {
+    const value = getPath(source, path);
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function firstRent(source: any, paths: string[]): number | null {
+  for (const path of paths) {
+    const value = parseRent(getPath(source, path));
+    if (value !== null && Number.isFinite(value) && value > 0) return value;
+  }
+  return null;
+}
+
+function extractBenchmarkObject(value: unknown): number | null {
+  const direct = cleanNumber(value);
+  if (direct !== null) return direct;
+  if (!value || typeof value !== 'object') return null;
+  return firstNumber(value, [
+    'value',
+    'price',
+    'benchmark',
+    'benchmark_price',
+    'benchmarkPrice',
+    'median',
+    'median_price',
+    'medianPrice',
+    'avg',
+    'average',
+    'average_price',
+    'avg_price',
+    'sold_price',
+    'soldPrice',
+  ]);
+}
+
+function getSoldBenchmark(property: any): { value: number | null; source: string | null } {
+  const candidates = [
+    { path: 'sold_comp_benchmark', label: 'sold comp benchmark' },
+    { path: 'soldCompBenchmark', label: 'sold comp benchmark' },
+    { path: 'comps.sales_benchmark', label: 'sales benchmark' },
+    { path: 'sold_comp_avg', label: 'average sold comp' },
+    { path: 'sold_comp_median', label: 'median sold comp' },
+    { path: 'avg_sale_comp', label: 'average sale comp' },
+    { path: 'derived.compsMedianSold', label: 'derived comps median' },
+    { path: 'compsMedianSold', label: 'derived comps median' },
+    { path: 'estimated_value', label: 'estimated value' },
+    { path: 'market_value', label: 'market value' },
+  ];
+
+  for (const candidate of candidates) {
+    const value = extractBenchmarkObject(getPath(property, candidate.path));
+    if (value !== null) return { value, source: candidate.label };
+  }
+  return { value: null, source: null };
+}
+
+function getCompsCount(property: any): number | null {
+  const direct = firstNumber(property, ['comps_count', 'compsCount', 'derived.compsCount']);
+  if (direct !== null) return Math.round(direct);
+  const sales = getPath(property, 'comps.sales');
+  return Array.isArray(sales) ? sales.length : null;
+}
+
+function getImageCount(property: any): number {
+  const imageUrls = property?.image_urls ?? property?.imageUrls;
+  if (Array.isArray(imageUrls)) return imageUrls.filter(Boolean).length + (property?.imageurl ? 1 : 0);
+  if (typeof imageUrls === 'string' && imageUrls.trim()) {
+    try {
+      const parsed = JSON.parse(imageUrls);
+      if (Array.isArray(parsed)) return parsed.filter(Boolean).length + (property?.imageurl ? 1 : 0);
+    } catch {
+      return 1 + (property?.imageurl ? 1 : 0);
+    }
+  }
+  return property?.imageurl ? 1 : 0;
+}
+
+function getRent(property: any, askingPrice: number | null): { monthlyRent: number | null; evidence: 'direct' | 'derived' | 'missing' } {
+  const directMonthly = firstRent(property, [
+    'monthly_rent',
+    'rent_pcm',
+    'rent_per_month',
+    'rental_evidence.monthly_rent',
+    'rental_evidence.rent_pcm',
+    'rental_evidence.rent_per_month',
+    'rentalEvidence.monthlyRent',
+  ]);
+  if (directMonthly !== null) return { monthlyRent: directMonthly, evidence: 'direct' };
+
+  const derived = firstNumber(property, ['derived.rentMonthly', 'rentMonthly']);
+  if (derived !== null) return { monthlyRent: derived, evidence: 'derived' };
+
+  const directRent = firstRent(property, ['rent', 'rental_evidence.rent', 'rentalEvidence.rent']);
+  if (directRent !== null) return { monthlyRent: directRent, evidence: 'direct' };
+
+  const yieldPct = firstNumber(property, ['yield_percent', 'gross_yield', 'rental_yield', 'derived.grossYieldPct', 'displayYieldPct']);
+  if (askingPrice && yieldPct !== null) return { monthlyRent: (askingPrice * yieldPct) / 100 / 12, evidence: 'derived' };
+
+  return { monthlyRent: null, evidence: 'missing' };
+}
+
+function getGrossYield(property: any, askingPrice: number | null, monthlyRent: number | null): number | null {
+  const direct = firstNumber(property, ['yield_percent', 'gross_yield', 'rental_yield', 'derived.grossYieldPct', 'displayYieldPct']);
+  if (direct !== null) return direct > 1 || direct === 0 ? direct : direct * 100;
+  if (askingPrice && monthlyRent) return (monthlyRent * 12 * 100) / askingPrice;
+  return null;
+}
+
+function getPriceReductionPct(property: any, askingPrice: number | null): number | null {
+  if (!askingPrice) return null;
+  const previous = firstNumber(property, ['previous_price', 'initial_price']);
+  const history = property?.price_history ?? property?.priceHistory;
+  const historyPrices = Array.isArray(history)
+    ? history.map((item) => cleanNumber(item?.price ?? item?.asking_price ?? item?.value)).filter((value): value is number => value !== null)
+    : [];
+  const oldPrice = Math.max(previous ?? 0, ...historyPrices, 0);
+  if (!oldPrice || oldPrice <= askingPrice) return null;
+  return ((oldPrice - askingPrice) * 100) / oldPrice;
+}
+
+function scorePricePosition(discountPct: number | null): number {
+  if (discountPct === null) return 0;
+  if (discountPct >= 18) return 35;
+  if (discountPct >= 12) return 30;
+  if (discountPct >= 7) return 24;
+  if (discountPct >= 3) return 17;
+  if (discountPct >= -3) return 10;
+  if (discountPct >= -10) return 3;
+  return 0;
+}
+
+function scoreYield(yieldPct: number | null): number {
+  if (yieldPct === null) return 0;
+  if (yieldPct >= 8) return 20;
+  if (yieldPct >= 7) return 18;
+  if (yieldPct >= 6) return 15;
+  if (yieldPct >= 5) return 10;
+  if (yieldPct >= 4) return 5;
+  return 1;
+}
+
+function scoreReduction(reductionPct: number | null): number {
+  if (reductionPct === null) return 0;
+  if (reductionPct >= 15) return 12;
+  if (reductionPct >= 10) return 10;
+  if (reductionPct >= 5) return 7;
+  if (reductionPct >= 2) return 4;
+  return 0;
+}
+
+function pricePositionLabel(discountPct: number | null): string {
+  if (discountPct === null) return 'No sold benchmark available';
+  if (discountPct >= 18) return `${formatPct(discountPct)} below sold benchmark`;
+  if (discountPct >= 7) return `${formatPct(discountPct)} below sold benchmark`;
+  if (discountPct >= 3) return `Slightly below benchmark (${formatPct(discountPct)})`;
+  if (discountPct >= -3) return 'Near sold benchmark';
+  return `${formatPct(Math.abs(discountPct))} above sold benchmark`;
+}
+
+function getText(property: any): string {
+  const textParts = [
+    property?.title,
+    property?.description,
+    property?.property_type,
+    property?.propertyType,
+    property?.investment_type,
+    property?.investmentType,
+    ...(Array.isArray(property?.top_deal_reasons) ? property.top_deal_reasons : []),
+    ...(Array.isArray(property?.deal_reasons) ? property.deal_reasons : []),
+    ...(Array.isArray(property?.deal_signals) ? property.deal_signals : []),
+  ];
+  return textParts.filter((value) => typeof value === 'string' && value.trim()).join(' ');
+}
+
+function buildSummary(code: DealLabelCode, priceLabel: string, yieldPct: number | null, evidence: 'direct' | 'derived' | 'missing'): string {
+  const yieldText = yieldPct !== null ? `${formatPct(yieldPct)} gross yield` : 'yield evidence missing';
+  const rentText = evidence === 'direct' ? 'direct rent evidence' : evidence === 'derived' ? 'derived rent evidence' : 'no rent evidence';
+  if (code === 'prime_deal') return `Strong evidence: ${priceLabel}, ${yieldText}, and ${rentText}. Complete diligence before offering.`;
+  if (code === 'strong_deal') return `Promising investor label based on ${priceLabel}, ${yieldText}, and ${rentText}. Verify the assumptions before bidding.`;
+  if (code === 'fair_deal') return `Reasonable evidence profile, but the property does not yet show enough edge for a premium deal label.`;
+  if (code === 'needs_review') return `Some useful signals are present, but missing evidence or risk wording means this needs manual investor review.`;
+  if (code === 'high_risk') return `The available evidence is weak or risk-heavy. Treat the listing as high diligence before considering an offer.`;
+  return `Evidence is too limited for a confident investor deal label. Add comparable sales, rent evidence and listing source checks.`;
+}
+
+function compactReason(result: Pick<DealLabelResult, 'code' | 'calculations' | 'pricePositionLabel'>): string {
+  if (result.code === 'insufficient_evidence') return 'Not enough comps or rent evidence yet.';
+  if (result.calculations.priceDiscountPct !== null && result.calculations.priceDiscountPct >= 7) return result.pricePositionLabel;
+  if (result.calculations.grossYieldPct !== null && result.calculations.grossYieldPct >= 6) return `${formatPct(result.calculations.grossYieldPct)} gross yield`;
+  if (result.calculations.priceReductionPct !== null && result.calculations.priceReductionPct >= 5) return `${formatPct(result.calculations.priceReductionPct)} price reduction`;
+  return result.calculations.rentEvidence === 'missing' ? 'Rent evidence needs checking.' : 'Evidence supports cautious review.';
+}
+
+export function formatMoney(value?: number | null): string {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 'N/A';
+  return new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: 'GBP',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function formatPct(value?: number | null): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'N/A';
+  return `${value.toFixed(1)}%`;
+}
+
+export function getDealLabelLegalCopy(): string {
+  return 'PropNexus deal labels are indicative only and are based on available listing, rental and comparable-market data. They are not formal valuations, financial advice, mortgage advice, tax advice or legal advice. Investors should verify all figures and seek professional advice before making an offer.';
+}
+
+export function computeDealLabel(property: any): DealLabelResult {
+  const askingPrice = firstNumber(property, ['price', 'asking_price', 'guide_price']);
+  const benchmark = getSoldBenchmark(property);
+  const compsCount = getCompsCount(property);
+  const rent = getRent(property, askingPrice);
+  const grossYieldPct = getGrossYield(property, askingPrice, rent.monthlyRent);
+  const priceReductionPct = getPriceReductionPct(property, askingPrice);
+  const priceDiscountPct = askingPrice && benchmark.value ? ((benchmark.value - askingPrice) * 100) / benchmark.value : null;
+  const imagesCount = getImageCount(property);
+  const postcode = firstString(property, ['postcode', 'postal_code', 'postalCode', 'postcode_full', 'postcodeFull']);
+  const sourceUrl = firstString(property, ['source_url', 'listing_url', 'original_url', 'property_url', 'external_url', 'rightmove_url', 'zoopla_url', 'onthemarket_url']);
+  const text = getText(property);
+
+  const positiveListingSignals = POSITIVE_SIGNAL_PATTERNS.filter((signal) => signal.pattern.test(text));
+  const riskListingSignals = RISK_SIGNAL_PATTERNS.filter((signal) => signal.pattern.test(text));
+  const listingPoints = clamp(
+    positiveListingSignals.reduce((sum, signal) => sum + signal.points, 0) - riskListingSignals.reduce((sum, signal) => sum + signal.points, 0),
+    0,
+    10,
+  );
+  const rentEvidencePoints = rent.evidence === 'direct' ? 12 : rent.evidence === 'derived' ? 9 : 0;
+  const pricePoints = scorePricePosition(priceDiscountPct);
+  const yieldPoints = scoreYield(grossYieldPct);
+  const reductionPoints = scoreReduction(priceReductionPct);
+
+  let dataQualityPoints = 0;
+  if (askingPrice) dataQualityPoints += 3;
+  if (benchmark.value) dataQualityPoints += 3;
+  if ((compsCount ?? 0) >= 3) dataQualityPoints += 3;
+  if (rent.evidence !== 'missing') dataQualityPoints += 3;
+  if (postcode) dataQualityPoints += 2;
+  if (sourceUrl) dataQualityPoints += 1;
+  if (imagesCount >= 3) dataQualityPoints += 1;
+
+  const penalties: Array<{ label: string; points: number }> = [];
+  if (!askingPrice) penalties.push({ label: 'Missing asking price', points: -14 });
+  if (!benchmark.value && rent.evidence === 'missing') penalties.push({ label: 'Missing comps and rent evidence', points: -18 });
+  if (!benchmark.value) penalties.push({ label: 'Missing sold benchmark', points: -8 });
+  if (rent.evidence === 'missing') penalties.push({ label: 'Missing rent evidence', points: -7 });
+  if (priceDiscountPct !== null && priceDiscountPct < -10) penalties.push({ label: 'More than 10% above benchmark', points: -12 });
+  if (grossYieldPct !== null && grossYieldPct > 35) penalties.push({ label: 'Unrealistic yield above 35%', points: -8 });
+  if (riskListingSignals.length) penalties.push({ label: 'Specialist risk wording found', points: -Math.min(8, riskListingSignals.length * 3) });
+
+  const rawScore = pricePoints + yieldPoints + rentEvidencePoints + reductionPoints + listingPoints + dataQualityPoints + penalties.reduce((sum, item) => sum + item.points, 0);
+  const score = Math.round(clamp(rawScore));
+  const confidence = Math.round(clamp(
+    (dataQualityPoints / 16) * 70
+      + (benchmark.value ? 10 : 0)
+      + (rent.evidence === 'direct' ? 12 : rent.evidence === 'derived' ? 8 : 0)
+      + ((compsCount ?? 0) >= 3 ? 8 : 0)
+      - (riskListingSignals.length ? 5 : 0),
+  ));
+  const hasStrongValueSignal = (priceDiscountPct !== null && priceDiscountPct >= 7) || (grossYieldPct !== null && grossYieldPct >= 6.5);
+
+  let code: DealLabelCode;
+  if (confidence < 18) code = 'insufficient_evidence';
+  else if (score >= 82 && confidence >= 55 && hasStrongValueSignal) code = 'prime_deal';
+  else if (score >= 68 && confidence >= 40 && hasStrongValueSignal) code = 'strong_deal';
+  else if (score >= 50) code = 'fair_deal';
+  else if (score >= 35) code = 'needs_review';
+  else code = 'high_risk';
+
+  const priceLabel = pricePositionLabel(priceDiscountPct);
+  const signals: DealLabelSignal[] = [
+    { key: 'price_position', label: 'Price position', points: pricePoints, max: 35, tone: pricePoints >= 24 ? 'emerald' : pricePoints >= 10 ? 'amber' : 'slate', detail: priceLabel },
+    { key: 'gross_yield', label: 'Gross yield', points: yieldPoints, max: 20, tone: yieldPoints >= 15 ? 'emerald' : yieldPoints >= 5 ? 'amber' : 'slate', detail: grossYieldPct !== null ? `${formatPct(grossYieldPct)} estimated gross yield` : 'No yield evidence available' },
+    { key: 'rent_evidence', label: 'Rent evidence', points: rentEvidencePoints, max: 12, tone: rentEvidencePoints >= 9 ? 'emerald' : 'slate', detail: rent.evidence === 'direct' ? 'Direct property rent evidence found' : rent.evidence === 'derived' ? 'Derived rent evidence found' : 'No rent evidence found' },
+    { key: 'price_reduction', label: 'Price reduction', points: reductionPoints, max: 12, tone: reductionPoints >= 7 ? 'emerald' : reductionPoints > 0 ? 'amber' : 'slate', detail: priceReductionPct !== null ? `${formatPct(priceReductionPct)} reduction from previous price` : 'No verified reduction found' },
+    { key: 'listing_signals', label: 'Listing signals', points: listingPoints, max: 10, tone: listingPoints >= 6 ? 'emerald' : riskListingSignals.length ? 'rose' : 'slate', detail: positiveListingSignals.length ? positiveListingSignals.map((signal) => signal.label).join(', ') : 'No value-add listing wording found' },
+    { key: 'data_quality', label: 'Data quality', points: dataQualityPoints, max: 16, tone: dataQualityPoints >= 12 ? 'emerald' : dataQualityPoints >= 7 ? 'amber' : 'rose', detail: 'Asking price, comps, rent, postcode, URL and image coverage' },
+  ];
+  const strongestSignals = signals
+    .filter((signal) => signal.points > 0)
+    .sort((a, b) => b.points / b.max - a.points / a.max)
+    .slice(0, 4)
+    .map((signal) => `${signal.label}: ${signal.detail}`);
+  const mainRisks = [
+    ...penalties.map((penalty) => penalty.label),
+    ...riskListingSignals.map((signal) => signal.label),
+    'Verify condition, lease, EPC, finance, fees and legal pack before offering',
+  ].filter((value, index, arr) => arr.indexOf(value) === index).slice(0, 5);
+
+  const partial: DealLabelResult = {
+    code,
+    label: LABELS[code].label,
+    score,
+    confidence,
+    tone: LABELS[code].tone,
+    summary: buildSummary(code, priceLabel, grossYieldPct, rent.evidence),
+    shortReason: '',
+    pricePositionLabel: priceLabel,
+    strongestSignals: strongestSignals.length ? strongestSignals : ['Evidence base is limited; validate comps and rent first'],
+    mainRisks,
+    signals,
+    calculations: {
+      askingPrice,
+      soldBenchmark: benchmark.value,
+      soldBenchmarkSource: benchmark.source,
+      priceDiscountPct,
+      grossYieldPct,
+      monthlyRent: rent.monthlyRent,
+      rentEvidence: rent.evidence,
+      priceReductionPct,
+      compsCount,
+      imagesCount,
+      positiveListingSignals: positiveListingSignals.map((signal) => signal.label),
+      riskListingSignals: riskListingSignals.map((signal) => signal.label),
+      dataQualityPoints,
+      penalties,
+    },
+  };
+
+  return { ...partial, shortReason: compactReason(partial) };
+}


### PR DESCRIPTION
Adds a professional Investor Deal Label system for PropNexus so investors can quickly understand deal quality from available evidence.

Summary:
- Added evidence-backed Investor Deal Label system.
- Added AutoTrader-style explainer modal.
- Added compact card chip.
- Added detail-page breakdown panel.
- Scoring is separate from AI Deal Score and uses price, comps, rent, reductions, listing signals and data quality.
- Added tests.

Validation:
- `npm --prefix frontend test -- dealLabel --runInBand`
- `npm --prefix frontend test -- PropertyCard.source-badge --runInBand`
- `npm --prefix frontend run lint`
- `NEXT_TELEMETRY_DISABLED=1 NEXT_PRIVATE_BUILD_WORKER=1 npm --prefix frontend run build`