### PR TITLE
feat(pivot): add analyse-any-deal intake flow

### DIFF
--- a/backend/routes/properties_routes.py
+++ b/backend/routes/properties_routes.py
@@ -41,6 +41,7 @@ from backend.utils.enrichment_store import (
     upsert_property_enrichment_cache,
 )
 from backend.utils.image_utils import dedupe_image_urls, pick_cover_image
+from backend.utils.internal_api_auth import require_internal_api_token
 from backend.utils.investment_type_classifier import classify_investment_types
 from backend.utils.listing_keys import best_postcode
 from backend.utils.property_type_classifier import (
@@ -271,6 +272,19 @@ class SearchPayload(BaseModel):
     allow_broaden: bool = True
     limit: int = Field(default=20, ge=1, le=100)
     offset: int = Field(default=0, ge=0)
+
+
+class UserSubmittedPropertyRequest(BaseModel):
+    source_url: str | None = Field(default=None, max_length=2048)
+    title: str = Field(min_length=1, max_length=240)
+    location: str = Field(min_length=1, max_length=240)
+    postcode: str | None = Field(default=None, max_length=24)
+    price: float = Field(gt=0, le=100_000_000)
+    bedrooms: int | None = Field(default=None, ge=0, le=50)
+    bathrooms: int | None = Field(default=None, ge=0, le=50)
+    property_type: str | None = Field(default=None, max_length=80)
+    estimated_monthly_rent: float | None = Field(default=None, ge=0, le=1_000_000)
+    description: str | None = Field(default=None, max_length=4000)
 
 
 def _log_search_query_metric(payload: dict[str, Any], total_results: int) -> None:
@@ -2374,6 +2388,123 @@ def get_property_investor_intel(property_id: str, response: Response):
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"investor intel fetch failed: {e}")
+
+
+@router.post("/properties/user-submitted")
+def create_user_submitted_property(
+    payload: UserSubmittedPropertyRequest,
+    request: Request,
+    x_propnexus_user_id: Optional[str] = Header(None, alias="X-PropNexus-User-Id"),
+    x_clerk_user_id: Optional[str] = Header(None, alias="X-Clerk-User-Id"),
+):
+    require_internal_api_token(request)
+
+    title = payload.title.strip()
+    location = payload.location.strip()
+    postcode = (
+        payload.postcode.strip().upper()
+        if isinstance(payload.postcode, str) and payload.postcode.strip()
+        else None
+    )
+    property_type = (
+        payload.property_type.strip()
+        if isinstance(payload.property_type, str) and payload.property_type.strip()
+        else None
+    )
+    description = (
+        payload.description.strip()
+        if isinstance(payload.description, str) and payload.description.strip()
+        else None
+    )
+    source_url = (
+        payload.source_url.strip()
+        if isinstance(payload.source_url, str) and payload.source_url.strip()
+        else None
+    )
+    user_id = (x_propnexus_user_id or x_clerk_user_id or "").strip() or None
+
+    if source_url:
+        parsed = urlparse(source_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise HTTPException(status_code=400, detail="Source URL must be a valid http(s) URL")
+
+    data_payload: Dict[str, Any] = {
+        "intake_mode": "analyse_any_deal",
+        "user_submitted": True,
+        "submitted_via": "analyse",
+        "user_provided_reference_only": bool(source_url),
+        "created_by": user_id,
+        "submitted_by": user_id,
+        "property_type": property_type,
+        "source_url": source_url,
+        "listing_url": source_url,
+        "original_listing_url": source_url,
+        "original_url": source_url,
+        "monthly_rent": payload.estimated_monthly_rent,
+        "rent_monthly": payload.estimated_monthly_rent,
+    }
+    if description:
+        data_payload["submission_notes"] = description
+
+    insert_payload: Dict[str, Any] = {
+        "title": title,
+        "description": description,
+        "location": location,
+        "address": location,
+        "postcode": postcode,
+        "price": round(float(payload.price), 2),
+        "bedrooms": payload.bedrooms,
+        "bathrooms": payload.bathrooms,
+        "property_type": property_type,
+        "source": "user_submitted",
+        "investment_type": "Buy-to-let",
+        "data": data_payload,
+    }
+    if payload.estimated_monthly_rent is not None:
+        insert_payload["rent_monthly"] = round(float(payload.estimated_monthly_rent), 2)
+    if source_url:
+        insert_payload["url"] = source_url
+        insert_payload["source_url"] = source_url
+        insert_payload["listing_url"] = source_url
+        insert_payload["original_listing_url"] = source_url
+        insert_payload["original_url"] = source_url
+
+    sb = _get_supabase()
+    try:
+        res = sb.table("properties").insert(insert_payload).execute()
+    except APIError:
+        retry_payload = dict(insert_payload)
+        for key in (
+            "source_url",
+            "listing_url",
+            "original_listing_url",
+            "original_url",
+            "rent_monthly",
+        ):
+            retry_payload.pop(key, None)
+        try:
+            res = sb.table("properties").insert(retry_payload).execute()
+        except Exception as retry_err:
+            raise HTTPException(
+                status_code=500, detail=f"property create failed: {retry_err}"
+            ) from retry_err
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"property create failed: {err}") from err
+
+    row = None
+    if isinstance(getattr(res, "data", None), list) and res.data:
+        row = res.data[0]
+    elif isinstance(getattr(res, "data", None), dict):
+        row = res.data
+
+    if not isinstance(row, dict) or not row.get("id"):
+        raise HTTPException(status_code=500, detail="property create failed: missing created id")
+
+    return {
+        "ok": True,
+        "property_id": row.get("id"),
+        "property": _normalize_property_row(row),
+    }
 
 
 @router.post("/properties/admin/backfill-scores")

--- a/backend/tests/test_user_submitted_property.py
+++ b/backend/tests/test_user_submitted_property.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+try:
+    from backend.main import app  # type: ignore
+
+    _import_error = None
+except Exception as e:  # pragma: no cover
+    app = None  # type: ignore[assignment]
+    _import_error = e
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    if app is None:  # pragma: no cover
+        pytest.skip(f"App unavailable in CI: {_import_error}")
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("PROPNEXUS_INTERNAL_API_TOKEN", "test-internal-token")
+    return TestClient(app)
+
+
+def _trusted_headers(user_id: str = "user_test") -> dict[str, str]:
+    return {
+        "X-PropNexus-Internal-Token": "test-internal-token",
+        "X-PropNexus-User-Id": user_id,
+        "X-Clerk-User-Id": user_id,
+    }
+
+
+class _Result:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeInsertQuery:
+    def __init__(self):
+        self.payload = None
+
+    def insert(self, payload: dict):
+        self.payload = payload
+        return self
+
+    def execute(self):
+        row = dict(self.payload)
+        row["id"] = "prop_user_submitted"
+        return _Result([row])
+
+
+class _FakeSupabase:
+    def __init__(self):
+        self.query = _FakeInsertQuery()
+
+    def table(self, name: str):
+        assert name == "properties"
+        return self.query
+
+
+def test_create_user_submitted_property_uses_reference_url_only(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import backend.routes.properties_routes as property_routes
+
+    fake = _FakeSupabase()
+    monkeypatch.setattr(property_routes, "_get_supabase", lambda: fake, raising=True)
+
+    response = client.post(
+        "/properties/user-submitted",
+        headers=_trusted_headers(),
+        json={
+            "source_url": "https://example.com/listing/42",
+            "title": "Investor deal",
+            "location": "Manchester",
+            "postcode": "M1 1AA",
+            "price": 225000,
+            "bedrooms": 2,
+            "bathrooms": 1,
+            "property_type": "Flat",
+            "estimated_monthly_rent": 1350,
+            "description": "User submitted notes",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["property_id"] == "prop_user_submitted"
+
+    payload = fake.query.payload
+    assert payload is not None
+    assert payload["source"] == "user_submitted"
+    assert payload["source_url"] == "https://example.com/listing/42"
+    assert payload["data"]["user_provided_reference_only"] is True
+    assert payload["data"]["rent_monthly"] == 1350

--- a/frontend/__tests__/analyse-page.spec.tsx
+++ b/frontend/__tests__/analyse-page.spec.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+
+import AnalysePage from '@/app/analyse/page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+describe('/analyse page', () => {
+  it('renders the manual deal intake form and legal-safe copy', () => {
+    render(<AnalysePage />);
+
+    expect(screen.getByRole('heading', { name: /analyse any uk property deal before you offer/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/listing\/source url optional/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/property title/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/address\/location/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /generate deal pack/i })).toBeInTheDocument();
+    expect(screen.getByText(/does not scrape or copy third-party listing pages in this flow/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/api-analyse-route.spec.ts
+++ b/frontend/__tests__/api-analyse-route.spec.ts
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockAuth = jest.fn();
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+}));
+
+describe('/api/analyse', () => {
+  const oldEnv = process.env;
+  const oldFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = {
+      ...oldEnv,
+      NEXT_PUBLIC_BACKEND_URL: 'https://backend.example',
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_test_123',
+      CLERK_SECRET_KEY: 'sk_test_123',
+      NEXT_PUBLIC_DISABLE_AUTH: 'false',
+      PROPNEXUS_INTERNAL_API_TOKEN: 'test-internal-token',
+    };
+    mockAuth.mockReset();
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+    global.fetch = oldFetch;
+  });
+
+  it('rejects invalid price payloads before calling upstream', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_1' });
+    global.fetch = jest.fn() as any;
+
+    const { POST } = await import('@/app/api/analyse/route');
+    const response = await POST(
+      new Request('http://localhost/api/analyse', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title: 'Deal', location: 'Leeds', price: -10 }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('validation_error');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('creates a user_submitted property and stores the URL only as reference data', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_2' });
+    global.fetch = jest.fn(async () => {
+      return new Response(
+        JSON.stringify({ ok: true, property_id: 'prop_123', property: { id: 'prop_123', source: 'user_submitted' } }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as any;
+
+    const { POST } = await import('@/app/api/analyse/route');
+    const response = await POST(
+      new Request('http://localhost/api/analyse', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          sourceUrl: 'https://example.com/listing/123',
+          title: 'Investor deal',
+          location: 'Leeds',
+          postcode: 'LS1 4AB',
+          price: 250000,
+          estimatedMonthlyRent: 1400,
+        }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.property_id).toBe('prop_123');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://backend.example/properties/user-submitted',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'X-PropNexus-Internal-Token': 'test-internal-token',
+          'x-propnexus-user-id': 'user_2',
+        }),
+        body: expect.stringContaining('"source_url":"https://example.com/listing/123"'),
+      }),
+    );
+    expect(global.fetch).not.toHaveBeenCalledWith('https://example.com/listing/123', expect.anything());
+  });
+});

--- a/frontend/app/analyse/page.tsx
+++ b/frontend/app/analyse/page.tsx
@@ -1,0 +1,316 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { FormEvent, useState } from 'react';
+import { FiArrowRight, FiCheckCircle, FiLink2 } from 'react-icons/fi';
+
+import InfoDisclaimer from '@/components/legal/InfoDisclaimer';
+import {
+  analyseDealSchema,
+  analysePropertyTypeOptions,
+  type AnalyseDealInput,
+} from '@/lib/analyseDealSchema';
+
+type FormState = {
+  sourceUrl: string;
+  title: string;
+  location: string;
+  postcode: string;
+  price: string;
+  bedrooms: string;
+  bathrooms: string;
+  propertyType: string;
+  estimatedMonthlyRent: string;
+  description: string;
+};
+
+type FieldErrorMap = Partial<Record<keyof FormState, string>>;
+
+const initialState: FormState = {
+  sourceUrl: '',
+  title: '',
+  location: '',
+  postcode: '',
+  price: '',
+  bedrooms: '',
+  bathrooms: '',
+  propertyType: '',
+  estimatedMonthlyRent: '',
+  description: '',
+};
+
+const inputClassName =
+  'h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-900 outline-none transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:placeholder:text-slate-500';
+
+function buildFieldErrors(form: FormState): FieldErrorMap {
+  const parsed = analyseDealSchema.safeParse({
+    sourceUrl: form.sourceUrl,
+    title: form.title,
+    location: form.location,
+    postcode: form.postcode,
+    price: form.price,
+    bedrooms: form.bedrooms,
+    bathrooms: form.bathrooms,
+    propertyType: form.propertyType,
+    estimatedMonthlyRent: form.estimatedMonthlyRent,
+    description: form.description,
+  } satisfies Record<keyof AnalyseDealInput, unknown>);
+
+  if (parsed.success) return {};
+
+  const flattened = parsed.error.flatten().fieldErrors as Record<string, string[] | undefined>;
+  const nextErrors: FieldErrorMap = {};
+  for (const [key, value] of Object.entries(flattened)) {
+    if (value && value.length > 0) {
+      nextErrors[key as keyof FormState] = value[0];
+    }
+  }
+  return nextErrors;
+}
+
+export default function AnalysePage() {
+  const router = useRouter();
+  const [form, setForm] = useState<FormState>(initialState);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrorMap>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function updateField(field: keyof FormState, value: string) {
+    setForm((current) => ({ ...current, [field]: value }));
+    setFieldErrors((current) => {
+      if (!current[field]) return current;
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  }
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    const nextErrors = buildFieldErrors(form);
+    if (Object.keys(nextErrors).length > 0) {
+      setFieldErrors(nextErrors);
+      setError('Check the highlighted deal details and try again.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await fetch('/api/analyse', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          sourceUrl: form.sourceUrl,
+          title: form.title,
+          location: form.location,
+          postcode: form.postcode,
+          price: form.price,
+          bedrooms: form.bedrooms,
+          bathrooms: form.bathrooms,
+          propertyType: form.propertyType,
+          estimatedMonthlyRent: form.estimatedMonthlyRent,
+          description: form.description,
+        }),
+      });
+
+      const result = await response.json().catch(() => null);
+      if (!response.ok) {
+        const serverFieldErrors = (result?.fieldErrors ?? {}) as Record<string, string[] | string | undefined>;
+        const nextServerErrors: FieldErrorMap = {};
+        for (const [key, value] of Object.entries(serverFieldErrors)) {
+          if (typeof value === 'string') {
+            nextServerErrors[key as keyof FormState] = value;
+          } else if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+            nextServerErrors[key as keyof FormState] = value[0];
+          }
+        }
+        if (Object.keys(nextServerErrors).length > 0) {
+          setFieldErrors(nextServerErrors);
+        }
+        throw new Error(result?.message || 'Could not generate a deal pack.');
+      }
+
+      const propertyId = String(result?.property_id || result?.property?.id || '').trim();
+      if (!propertyId) {
+        throw new Error('Deal created but no property id was returned.');
+      }
+
+      router.push(`/property/${encodeURIComponent(propertyId)}`);
+    } catch (submitError: any) {
+      setError(submitError?.message || 'Could not generate a deal pack.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
+      <section className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+        <div className="grid gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-start">
+          <div className="space-y-6">
+            <div className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-sky-50 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-sky-700 dark:border-sky-900/60 dark:bg-sky-950/30 dark:text-sky-200">
+              <FiCheckCircle className="h-4 w-4" aria-hidden="true" />
+              Analyse Any Deal
+            </div>
+
+            <div>
+              <h1 className="text-4xl font-bold tracking-tight text-slate-950 dark:text-white sm:text-5xl">
+                Analyse any UK property deal before you offer
+              </h1>
+              <p className="mt-4 max-w-2xl text-lg leading-8 text-slate-600 dark:text-slate-300">
+                Paste a listing link, enter the key details, and PropNexus will generate an investor-ready Deal Pack.
+              </p>
+            </div>
+
+            <InfoDisclaimer className="max-w-2xl">
+              You provide the property information. PropNexus enriches it using available public, licensed and user-supplied data.
+            </InfoDisclaimer>
+
+            <div className="grid gap-4 rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-white">What happens next</h2>
+                <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+                  We create a user-submitted deal record, carry the listing URL as a reference only, and open the existing property detail workflow so you can review score, rent, offer logic and next steps in one place.
+                </p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/60">
+                  <div className="text-sm font-semibold text-slate-900 dark:text-white">Investor-ready output</div>
+                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">Reuse the current detail page, score panels, offer intelligence and saved deal workflow.</div>
+                </div>
+                <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/60">
+                  <div className="text-sm font-semibold text-slate-900 dark:text-white">Reference URL only</div>
+                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">Source URLs are treated as user-provided references only and are never fetched here.</div>
+                </div>
+              </div>
+              <div>
+                <Link href="/listings" className="inline-flex items-center gap-2 text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300">
+                  Browse current listings instead
+                  <FiArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-xl shadow-slate-200/40 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/20 sm:p-8">
+            <form className="space-y-5" onSubmit={onSubmit}>
+              <FormField label="Listing/source URL optional" htmlFor="sourceUrl" error={fieldErrors.sourceUrl}>
+                <div className="relative">
+                  <FiLink2 className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+                  <input
+                    id="sourceUrl"
+                    name="sourceUrl"
+                    type="url"
+                    value={form.sourceUrl}
+                    onChange={(event) => updateField('sourceUrl', event.target.value)}
+                    placeholder="https://example.com/listing"
+                    className={`${inputClassName} pl-11`}
+                  />
+                </div>
+              </FormField>
+
+              <div className="grid gap-5 sm:grid-cols-2">
+                <FormField label="Property title" htmlFor="title" required error={fieldErrors.title}>
+                  <input id="title" name="title" value={form.title} onChange={(event) => updateField('title', event.target.value)} className={inputClassName} />
+                </FormField>
+                <FormField label="Postcode" htmlFor="postcode" error={fieldErrors.postcode}>
+                  <input id="postcode" name="postcode" value={form.postcode} onChange={(event) => updateField('postcode', event.target.value)} className={inputClassName} />
+                </FormField>
+              </div>
+
+              <FormField label="Address/location" htmlFor="location" required error={fieldErrors.location}>
+                <input id="location" name="location" value={form.location} onChange={(event) => updateField('location', event.target.value)} className={inputClassName} />
+              </FormField>
+
+              <div className="grid gap-5 sm:grid-cols-2">
+                <FormField label="Asking price" htmlFor="price" required error={fieldErrors.price}>
+                  <input id="price" name="price" inputMode="decimal" value={form.price} onChange={(event) => updateField('price', event.target.value)} placeholder="250000" className={inputClassName} />
+                </FormField>
+                <FormField label="Property type" htmlFor="propertyType" error={fieldErrors.propertyType}>
+                  <select id="propertyType" name="propertyType" value={form.propertyType} onChange={(event) => updateField('propertyType', event.target.value)} className={inputClassName}>
+                    <option value="">Select property type</option>
+                    {analysePropertyTypeOptions.map((type) => (
+                      <option key={type} value={type}>
+                        {type}
+                      </option>
+                    ))}
+                  </select>
+                </FormField>
+              </div>
+
+              <div className="grid gap-5 sm:grid-cols-3">
+                <FormField label="Bedrooms" htmlFor="bedrooms" error={fieldErrors.bedrooms}>
+                  <input id="bedrooms" name="bedrooms" inputMode="numeric" value={form.bedrooms} onChange={(event) => updateField('bedrooms', event.target.value)} className={inputClassName} />
+                </FormField>
+                <FormField label="Bathrooms" htmlFor="bathrooms" error={fieldErrors.bathrooms}>
+                  <input id="bathrooms" name="bathrooms" inputMode="numeric" value={form.bathrooms} onChange={(event) => updateField('bathrooms', event.target.value)} className={inputClassName} />
+                </FormField>
+                <FormField label="Estimated monthly rent" htmlFor="estimatedMonthlyRent" error={fieldErrors.estimatedMonthlyRent}>
+                  <input id="estimatedMonthlyRent" name="estimatedMonthlyRent" inputMode="decimal" value={form.estimatedMonthlyRent} onChange={(event) => updateField('estimatedMonthlyRent', event.target.value)} placeholder="1400" className={inputClassName} />
+                </FormField>
+              </div>
+
+              <FormField label="Notes/description" htmlFor="description" error={fieldErrors.description}>
+                <textarea
+                  id="description"
+                  name="description"
+                  rows={5}
+                  value={form.description}
+                  onChange={(event) => updateField('description', event.target.value)}
+                  className={`${inputClassName} min-h-[8rem] py-3`}
+                />
+              </FormField>
+
+              <InfoDisclaimer className="w-full text-left">
+                PropNexus does not scrape or copy third-party listing pages in this flow. You are responsible for the information you provide. PropNexus outputs are indicative only and are not valuations, financial advice, mortgage advice, tax advice or legal advice.
+              </InfoDisclaimer>
+
+              {error ? (
+                <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900 dark:border-rose-900/60 dark:bg-rose-950/30 dark:text-rose-100">
+                  {error}
+                </div>
+              ) : null}
+
+              <button
+                type="submit"
+                disabled={submitting}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-brand-500 to-brand-600 px-5 py-3 text-sm font-semibold text-white transition hover:from-brand-600 hover:to-brand-700 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <span>{submitting ? 'Generating…' : 'Generate Deal Pack'}</span>
+                <FiArrowRight className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </form>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function FormField({
+  label,
+  htmlFor,
+  required,
+  error,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  required?: boolean;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block" htmlFor={htmlFor}>
+      <span className="mb-2 block text-sm font-semibold text-slate-900 dark:text-white">
+        {label}
+        {required ? <span className="ml-1 text-rose-500">*</span> : null}
+      </span>
+      {children}
+      {error ? <span className="mt-2 block text-sm text-rose-600 dark:text-rose-300">{error}</span> : null}
+    </label>
+  );
+}

--- a/frontend/app/api/analyse/route.ts
+++ b/frontend/app/api/analyse/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+
+import { analyseDealSchema } from '@/lib/analyseDealSchema';
+import { internalApiHeaders, isInternalApiConfigError } from '@/lib/server/internalApi';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getBackendBase(): string {
+  const base = (
+    process.env.NEXT_PUBLIC_BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_BASE ||
+    ''
+  ).trim();
+
+  if (base) return base.replace(/\/+$/, '');
+  if (process.env.NODE_ENV !== 'production') return 'http://localhost:8000';
+  throw new Error('Missing backend base URL env (NEXT_PUBLIC_BACKEND_URL / NEXT_PUBLIC_API_URL / BACKEND_URL).');
+}
+
+function isClerkServerEnabled(): boolean {
+  const pk = (process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '').trim();
+  const sk = (process.env.CLERK_SECRET_KEY ?? '').trim();
+  const disable = ['1', 'true', 'yes', 'on'].includes(
+    (process.env.NEXT_PUBLIC_DISABLE_AUTH ?? '').trim().toLowerCase(),
+  );
+
+  return !disable && pk.startsWith('pk_') && Boolean(sk);
+}
+
+async function getVerifiedUserId(): Promise<string | null> {
+  if (!isClerkServerEnabled()) return null;
+
+  const session: any = await auth();
+  return (session?.userId as string | null) ?? null;
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => null);
+    const parsed = analyseDealSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'validation_error',
+          message: parsed.error.issues[0]?.message ?? 'Invalid input.',
+          fieldErrors: parsed.error.flatten().fieldErrors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const userId = await getVerifiedUserId();
+    if (isClerkServerEnabled() && !userId) {
+      return NextResponse.json(
+        { ok: false, error: 'unauthorized', message: 'You must be signed in to create a deal.' },
+        { status: 401 },
+      );
+    }
+
+    const payload = parsed.data;
+    const upstream = await fetch(`${getBackendBase()}/properties/user-submitted`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...internalApiHeaders(),
+        ...(userId ? { 'x-propnexus-user-id': userId, 'x-clerk-user-id': userId } : {}),
+      },
+      body: JSON.stringify({
+        source_url: payload.sourceUrl,
+        title: payload.title,
+        location: payload.location,
+        postcode: payload.postcode,
+        price: payload.price,
+        bedrooms: payload.bedrooms,
+        bathrooms: payload.bathrooms,
+        property_type: payload.propertyType,
+        estimated_monthly_rent: payload.estimatedMonthlyRent,
+        description: payload.description,
+      }),
+      cache: 'no-store',
+    });
+
+    const text = await upstream.text();
+    try {
+      const json = text ? JSON.parse(text) : null;
+      return NextResponse.json(json, { status: upstream.status });
+    } catch {
+      return new NextResponse(text, {
+        status: upstream.status,
+        headers: { 'content-type': upstream.headers.get('content-type') || 'text/plain' },
+      });
+    }
+  } catch (err: any) {
+    if (isInternalApiConfigError(err)) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'server_configuration',
+          message: 'Deal creation is temporarily unavailable. Please try again shortly.',
+        },
+        { status: 503 },
+      );
+    }
+
+    return NextResponse.json(
+      { ok: false, error: 'server_error', message: 'Could not create this deal.' },
+      { status: 502 },
+    );
+  }
+}

--- a/frontend/app/listings/page.tsx
+++ b/frontend/app/listings/page.tsx
@@ -1986,9 +1986,14 @@ function ListingsInner() {
                 {sort === 'top_deals' && watchlistTopDeals.length > 0 ? (
                   <p className="mt-2 text-sm text-slate-500">{watchlistTopDeals.length} watchlist leads are available, but they do not meet Top Deal confidence yet.</p>
                 ) : null}
-                <button onClick={resetFilters} className="btn-primary mt-4">
-                  Clear Filters
-                </button>
+                <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+                  <button onClick={resetFilters} className="btn-primary">
+                    Clear Filters
+                  </button>
+                  <Link href="/analyse" className="rounded-md border border-slate-300 dark:border-slate-700 px-5 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors inline-flex">
+                    Analyse your own deal instead
+                  </Link>
+                </div>
               </div>
             ) : (
               <>
@@ -2059,9 +2064,14 @@ function ListingsInner() {
                   <p className="text-xl text-slate-600 dark:text-slate-400">
                     {sort === 'top_deals' ? 'No high-confidence Top Deals surfaced in this search yet.' : 'No properties match these filters.'}
                   </p>
-                  <button onClick={resetFilters} className="btn-primary mt-4">
-                    Clear Filters
-                  </button>
+                  <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+                    <button onClick={resetFilters} className="btn-primary">
+                      Clear Filters
+                    </button>
+                    <Link href="/analyse" className="rounded-md border border-slate-300 dark:border-slate-700 px-5 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors inline-flex">
+                      Analyse your own deal instead
+                    </Link>
+                  </div>
                 </div>
               ) : (
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -94,20 +94,20 @@ export default function HomePage() {
             {/* Badge */}
             <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/20 px-3 py-1.5 backdrop-blur-sm lg:mb-4">
               <FiZap className="w-4 h-4 text-white" />
-              <span className="text-xs font-semibold tracking-[0.16em] text-white sm:text-sm">AI-Powered Property Platform</span>
+              <span className="text-xs font-semibold tracking-[0.16em] text-white sm:text-sm">AI Deal Desk for UK Property Investors</span>
             </div>
 
             {/* Headline */}
             <h1 className="mb-4 text-4xl font-bold leading-[1.02] text-white sm:text-5xl lg:mb-4 lg:text-6xl xl:text-[4rem]">
-              Discover Your Next
+              Analyse Any UK
               <br />
               <span className="bg-gradient-to-r from-white to-cyan-100 bg-clip-text text-transparent">
-                Investment Property
+                Property Deal Before You Offer
               </span>
             </h1>
 
             <p className="mb-14 max-w-2xl text-lg leading-7 text-brand-50 sm:text-xl lg:mx-0 lg:mb-12 xl:text-[1.35rem] xl:leading-8">
-              Smart property sourcing powered by AI. Analyze yields, calculate ROI, and find the perfect investment with confidence.
+              Paste a listing link or enter the key details to generate an investor-ready Deal Pack, offer range context, and risk-first analysis.
             </p>
 
             {/* Search Form */}
@@ -140,18 +140,22 @@ export default function HomePage() {
             {/* CTA Buttons */}
             <div className="mb-8 flex flex-col items-center justify-center gap-3 sm:flex-row lg:mb-7 lg:justify-start">
               <Link
-                href="/listings"
+                href="/analyse"
                 className="btn-primary px-7 py-3 text-base lg:text-lg"
+              >
+                Analyse a deal
+              </Link>
+              <Link
+                href="/listings"
+                className="btn-secondary border-2 border-white/50 bg-white/10 px-7 py-3 text-base text-white backdrop-blur-sm hover:bg-white/20 lg:text-lg"
               >
                 Browse listings
               </Link>
-              <Link
-                href="/pricing"
-                className="btn-secondary border-2 border-white/50 bg-white/10 px-7 py-3 text-base text-white backdrop-blur-sm hover:bg-white/20 lg:text-lg"
-              >
-                View Pricing
-              </Link>
             </div>
+
+            <p className="mb-6 max-w-2xl text-sm leading-6 text-brand-100 lg:mb-5">
+              You provide the property information. PropNexus enriches it using available public, licensed and user-supplied data.
+            </p>
 
             {/* Stats */}
             <div className="grid max-w-3xl grid-cols-1 gap-4 rounded-3xl border border-white/15 bg-white/10 p-5 backdrop-blur-md sm:grid-cols-3 sm:gap-5 lg:mx-0 lg:max-w-2xl lg:bg-white/12 lg:p-4">
@@ -216,10 +220,10 @@ export default function HomePage() {
             Join thousands of investors who trust PropNexus to find their next property.
           </p>
           <Link
-            href="/magic-login"
+            href="/analyse"
             className="btn-primary text-lg px-8 py-4"
           >
-            <span>Get Started Free</span>
+            <span>Generate Deal Pack</span>
             <FiZap className="w-5 h-5" />
           </Link>
         </div>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -23,6 +23,7 @@ export default function Header() {
   const pathname = usePathname();
   const links = [
     { href: '/', label: t('nav.home') },
+    { href: '/analyse', label: t('nav.analyse') },
     { href: '/listings', label: t('nav.listings') },
     { href: '/saved', label: t('nav.savedDeals') },
     ...(FF.OFF_MARKET ? [{ href: '/off-market', label: t('nav.offMarket') }] : []),

--- a/frontend/lib/analyseDealSchema.ts
+++ b/frontend/lib/analyseDealSchema.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+function textOrUndefined(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : Number.NaN;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    const parsed = Number(trimmed.replace(/,/g, ''));
+    return Number.isFinite(parsed) ? parsed : Number.NaN;
+  }
+  return Number.NaN;
+}
+
+export const analysePropertyTypeOptions = [
+  'Flat',
+  'Terraced',
+  'Semi-detached',
+  'Detached',
+  'Bungalow',
+  'Maisonette',
+  'Studio',
+  'Mixed use',
+  'Commercial',
+  'Land',
+] as const;
+
+export const analyseDealSchema = z.object({
+  sourceUrl: z
+    .preprocess(textOrUndefined, z.string().url('Enter a valid http(s) URL.').max(2048).optional()),
+  title: z.preprocess(textOrUndefined, z.string().min(1, 'Property title is required.').max(240)),
+  location: z.preprocess(textOrUndefined, z.string().min(1, 'Address or location is required.').max(240)),
+  postcode: z.preprocess(textOrUndefined, z.string().max(24).optional()),
+  price: z.preprocess(
+    numberOrUndefined,
+    z.number().finite('Enter a valid asking price.').positive('Asking price must be greater than zero.').max(100000000),
+  ),
+  bedrooms: z.preprocess(numberOrUndefined, z.number().int('Bedrooms must be a whole number.').min(0).max(50).optional()),
+  bathrooms: z.preprocess(numberOrUndefined, z.number().int('Bathrooms must be a whole number.').min(0).max(50).optional()),
+  propertyType: z.preprocess(textOrUndefined, z.string().max(80).optional()),
+  estimatedMonthlyRent: z.preprocess(
+    numberOrUndefined,
+    z.number().finite('Enter a valid monthly rent.').min(0).max(1000000).optional(),
+  ),
+  description: z.preprocess(textOrUndefined, z.string().max(4000).optional()),
+});
+
+export type AnalyseDealInput = z.infer<typeof analyseDealSchema>;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -10,6 +10,7 @@
     "closeMenu": "Close menu",
     "nav": {
       "home": "Home",
+      "analyse": "Analyse Deal",
       "listings": "Listings",
       "savedDeals": "Saved Deals",
       "offMarket": "Off-Market",


### PR DESCRIPTION
## Summary
- created pivot sprint issues for the new PropNexus Deal Desk direction: #451, #452, #453, #454, #455, #456
- added `/analyse` as a user-submitted deal intake flow that creates `source=user_submitted` properties and redirects into the existing property detail workflow
- added legal-safe user-submitted source wording and treated listing URLs as user-provided references only
- added a backend/frontend API flow for creating user-submitted deals without scraping
- added CTA links from the homepage, header, and listings empty states to `/analyse`
- reused the existing property detail analysis experience instead of creating a parallel deal view

## Validation
- `npm --prefix frontend run test -- --runTestsByPath __tests__/analyse-page.spec.tsx __tests__/api-analyse-route.spec.ts`
- `npm --prefix frontend run lint`
- `NEXT_TELEMETRY_DISABLED=1 NEXT_PRIVATE_BUILD_WORKER=1 npm --prefix frontend run build`

## Notes
- no scraping was added in this flow
- backend pytest coverage was added for the new endpoint, but I did not run a Python-targeted command in this pass
