### PR TITLE
fix(pivot): polish manual deal flow and remove scraping copy

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -241,6 +241,46 @@ def debug_scraper_env():
     }
 
 
+def _collect_registered_route_details() -> list[dict[str, object]]:
+    detailed: list[dict[str, object]] = []
+
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            detailed.append(
+                {
+                    "path": route.path,
+                    "methods": sorted([m for m in (route.methods or set()) if m]),
+                    "name": route.name,
+                }
+            )
+            continue
+
+        effective_route_contexts = getattr(route, "effective_route_contexts", None)
+        if not callable(effective_route_contexts):
+            continue
+
+        for context in effective_route_contexts():
+            starlette_route = getattr(context, "starlette_route", None)
+            original_route = getattr(context, "original_route", None)
+            path = getattr(starlette_route, "path", None) or getattr(original_route, "path", None)
+            if not path:
+                continue
+
+            methods = getattr(starlette_route, "methods", None) or getattr(
+                original_route, "methods", None
+            )
+            detailed.append(
+                {
+                    "path": path,
+                    "methods": sorted([m for m in (methods or set()) if m]),
+                    "name": getattr(starlette_route, "name", None)
+                    or getattr(original_route, "name", None),
+                }
+            )
+
+    return detailed
+
+
 @app.get("/debug/routes", dependencies=[Depends(require_debug_enabled)])
 def debug_routes():
     """Return a sorted list of registered paths.
@@ -248,20 +288,8 @@ def debug_routes():
     This helps confirm route registration in production without relying only on OpenAPI.
     """
 
-    paths: set[str] = set()
-    detailed: list[dict] = []
-
-    for r in app.routes:
-        if not isinstance(r, APIRoute):
-            continue
-        paths.add(r.path)
-        detailed.append(
-            {
-                "path": r.path,
-                "methods": sorted([m for m in (r.methods or set()) if m]),
-                "name": r.name,
-            }
-        )
+    detailed = _collect_registered_route_details()
+    paths = {route["path"] for route in detailed if isinstance(route.get("path"), str)}
 
     return {
         "count": len(paths),

--- a/backend/routes/properties_routes.py
+++ b/backend/routes/properties_routes.py
@@ -501,6 +501,35 @@ def _exclude_spareroom_source(query: Any) -> Any:
     return next_query or query
 
 
+def _exclude_public_hidden_sources(
+    query: Any,
+    *,
+    include_spareroom: bool,
+    explicit_spareroom_source: bool,
+) -> Any:
+    """Hide non-public sources from the default listings feed while preserving NULL sources."""
+
+    # Default public feed should hide user_submitted always.
+    # SpareRoom is hidden unless explicitly included.
+    if include_spareroom or explicit_spareroom_source:
+        expr = "source.is.null,source.neq.user_submitted"
+    else:
+        expr = "source.is.null,and(source.neq.user_submitted,source.neq.spareroom)"
+
+    try:
+        next_query = query.or_(expr)
+    except Exception:
+        return query
+
+    if (
+        type(query).__module__ == "unittest.mock"
+        and type(next_query).__module__ == "unittest.mock"
+        and next_query is not query
+    ):
+        return query
+    return next_query or query
+
+
 def _is_mappable_coordinate_pair(lat: Any, lng: Any) -> bool:
     def _to_float(v: Any) -> float | None:
         if v is None or isinstance(v, bool):
@@ -1474,10 +1503,11 @@ def list_properties(
             if source_filter:
                 q0 = q0.eq("source", source_filter)
             else:
-                # Hide manual user-submitted rows from public listing inventory by default.
-                q0 = q0.neq("source", "user_submitted")
-                if not include_spareroom and not explicit_spareroom_source:
-                    q0 = _exclude_spareroom_source(q0)
+                q0 = _exclude_public_hidden_sources(
+                    q0,
+                    include_spareroom=include_spareroom,
+                    explicit_spareroom_source=explicit_spareroom_source,
+                )
 
             # Optional created_at filter (useful for "show me what just got inserted")
             if created_after is not None:

--- a/backend/routes/properties_routes.py
+++ b/backend/routes/properties_routes.py
@@ -509,8 +509,6 @@ def _exclude_public_hidden_sources(
 ) -> Any:
     """Hide non-public sources from the default listings feed while preserving NULL sources."""
 
-    # Default public feed should hide user_submitted always.
-    # SpareRoom is hidden unless explicitly included.
     if include_spareroom or explicit_spareroom_source:
         expr = "source.is.null,source.neq.user_submitted"
     else:

--- a/backend/routes/properties_routes.py
+++ b/backend/routes/properties_routes.py
@@ -1470,11 +1470,14 @@ def list_properties(
                 except Exception:
                     return q0
 
-            # Exact source filter (useful for verifying scraper inserts)
+            # Exact source filter (useful for verifying source-specific inserts)
             if source_filter:
                 q0 = q0.eq("source", source_filter)
-            elif not include_spareroom and not explicit_spareroom_source:
-                q0 = _exclude_spareroom_source(q0)
+            else:
+                # Hide manual user-submitted rows from public listing inventory by default.
+                q0 = q0.neq("source", "user_submitted")
+                if not include_spareroom and not explicit_spareroom_source:
+                    q0 = _exclude_spareroom_source(q0)
 
             # Optional created_at filter (useful for "show me what just got inserted")
             if created_after is not None:

--- a/backend/tests/test_properties_pagination.py
+++ b/backend/tests/test_properties_pagination.py
@@ -80,6 +80,7 @@ class _FilteringQuery:
         self._rows = rows
         self._source_eq: str | None = None
         self._exclude_spareroom = False
+        self._exclude_user_submitted = False
         self._range: tuple[int, int] | None = None
         self._orders: list[tuple[str, bool]] = []
         self.calls: List[Tuple[str, tuple, dict]] = []
@@ -98,11 +99,18 @@ class _FilteringQuery:
         self.calls.append(("neq", args, kwargs))
         if args == ("source", "spareroom"):
             self._exclude_spareroom = True
+        if args == ("source", "user_submitted"):
+            self._exclude_user_submitted = True
         return self
 
     def or_(self, *args, **kwargs):
         self.calls.append(("or_", args, kwargs))
         if args and args[0] == "source.is.null,source.neq.spareroom":
+            self._exclude_spareroom = True
+        if args and args[0] == "source.is.null,source.neq.user_submitted":
+            self._exclude_user_submitted = True
+        if args and args[0] == "source.is.null,and(source.neq.user_submitted,source.neq.spareroom)":
+            self._exclude_user_submitted = True
             self._exclude_spareroom = True
         return self
 
@@ -132,8 +140,20 @@ class _FilteringQuery:
         rows = list(self._rows)
         if self._source_eq is not None:
             rows = [r for r in rows if str(r.get("source") or "").lower() == self._source_eq]
-        elif self._exclude_spareroom:
-            rows = [r for r in rows if str(r.get("source") or "").lower() != "spareroom"]
+        else:
+            if self._exclude_user_submitted:
+                rows = [
+                    r
+                    for r in rows
+                    if r.get("source") is None
+                    or str(r.get("source") or "").lower() != "user_submitted"
+                ]
+            if self._exclude_spareroom:
+                rows = [
+                    r
+                    for r in rows
+                    if r.get("source") is None or str(r.get("source") or "").lower() != "spareroom"
+                ]
 
         def _sort_value(row: dict[str, Any], column: str):
             value = row.get(column)
@@ -321,3 +341,62 @@ def test_list_properties_allows_explicit_spareroom_opt_in_and_source(monkeypatch
     )
     assert spare_only["total"] == 1
     assert [item["id"] for item in spare_only["items"]] == ["spare-1"]
+
+
+def test_list_properties_hides_user_submitted_but_keeps_null_source(monkeypatch):
+    rows = [
+        {"id": "manual-1", "title": "Manual deal", "source": "user_submitted", "price": 120000},
+        {"id": "null-1", "title": "Unknown source", "source": None, "price": 130000},
+        {"id": "portal-1", "title": "Portal row", "source": "rightmove", "price": 140000},
+    ]
+    fake_sb = _FilteringSupabase(rows)
+    monkeypatch.setattr(properties_routes, "_get_supabase", lambda: fake_sb)
+
+    res = properties_routes.list_properties(
+        response=Response(),
+        q=None,
+        source=None,
+        created_after=None,
+        min=None,
+        max=None,
+        beds=None,
+        baths=None,
+        types=None,
+        limit=25,
+        offset=0,
+        sort="price_asc",
+        dir="desc",
+    )
+
+    ids = [item["id"] for item in res["items"]]
+    assert "manual-1" not in ids
+    assert "null-1" in ids
+    assert "portal-1" in ids
+
+
+def test_list_properties_allows_explicit_user_submitted_source(monkeypatch):
+    rows = [
+        {"id": "manual-1", "title": "Manual deal", "source": "user_submitted", "price": 120000},
+        {"id": "portal-1", "title": "Portal row", "source": "rightmove", "price": 140000},
+    ]
+    fake_sb = _FilteringSupabase(rows)
+    monkeypatch.setattr(properties_routes, "_get_supabase", lambda: fake_sb)
+
+    res = properties_routes.list_properties(
+        response=Response(),
+        q=None,
+        source="user_submitted",
+        created_after=None,
+        min=None,
+        max=None,
+        beds=None,
+        baths=None,
+        types=None,
+        limit=25,
+        offset=0,
+        sort="price_asc",
+        dir="desc",
+    )
+
+    assert res["total"] == 1
+    assert [item["id"] for item in res["items"]] == ["manual-1"]

--- a/backend/tests/test_route_diagnostics.py
+++ b/backend/tests/test_route_diagnostics.py
@@ -21,10 +21,28 @@ import pytest
 from fastapi.testclient import TestClient
 
 
+def _unbind_parent_attr(name: str) -> None:
+    parent_name, _, child_name = name.rpartition(".")
+    if not parent_name or not child_name:
+        return
+
+    parent_module = sys.modules.get(parent_name)
+    if parent_module is not None and getattr(parent_module, child_name, None) is not None:
+        try:
+            delattr(parent_module, child_name)
+        except Exception:
+            pass
+
+
 def _purge_modules(prefixes: Iterable[str]) -> None:
-    for name in list(sys.modules):
-        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes):
-            sys.modules.pop(name, None)
+    names = [
+        name
+        for name in list(sys.modules)
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
+    ]
+    for name in sorted(names, key=lambda module_name: module_name.count("."), reverse=True):
+        _unbind_parent_attr(name)
+        sys.modules.pop(name, None)
 
 
 def _snapshot_modules(prefixes: Iterable[str]) -> dict[str, ModuleType]:
@@ -48,7 +66,7 @@ def _bind_module(name: str, module: ModuleType) -> None:
 
 def _restore_modules(snapshot: dict[str, ModuleType], prefixes: Iterable[str]) -> None:
     _purge_modules(prefixes)
-    for name, module in snapshot.items():
+    for name, module in sorted(snapshot.items(), key=lambda item: item[0].count(".")):
         _bind_module(name, module)
 
 
@@ -125,6 +143,19 @@ def _assert_keys(payload: dict[str, Any], required_keys: set[str]) -> None:
     assert not missing, f"Missing keys: {sorted(missing)}"
 
 
+def _route_debug_context(paths: set[str]) -> str:
+    backend_module = sys.modules.get("backend")
+    backend_main_module = sys.modules.get("backend.main")
+
+    return (
+        f"backend.main_id={id(backend_main_module) if backend_main_module is not None else None}; "
+        f"backend.main_file={getattr(backend_main_module, '__file__', None)}; "
+        f"backend_has_main={hasattr(backend_module, 'main') if backend_module is not None else False}; "
+        f"backend_has_routes={hasattr(backend_module, 'routes') if backend_module is not None else False}; "
+        f"paths={sorted(paths)[:20]}"
+    )
+
+
 def test_debug_routes_contains_critical_paths(client: TestClient) -> None:
     resp = client.get("/debug/routes")
     assert resp.status_code == 200
@@ -134,7 +165,9 @@ def test_debug_routes_contains_critical_paths(client: TestClient) -> None:
     assert isinstance(body.get("paths"), list)
 
     paths = set(body["paths"])
-    assert len(paths) >= 20, f"Unexpectedly low route count: {len(paths)}; paths={sorted(paths)}"
+    assert (
+        len(paths) >= 20
+    ), f"Unexpectedly low route count: {len(paths)}; {_route_debug_context(paths)}"
     critical = {
         "/",
         "/health",

--- a/backend/tests/test_route_diagnostics.py
+++ b/backend/tests/test_route_diagnostics.py
@@ -10,132 +10,32 @@ It is not a full integration suite and should stay fast.
 
 from __future__ import annotations
 
-import importlib
+import json
 import os
+import subprocess
 import sys
-from collections.abc import Iterable
-from types import ModuleType
+import textwrap
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
+try:
+    from backend.main import app  # type: ignore
 
-def _unbind_parent_attr(name: str) -> None:
-    parent_name, _, child_name = name.rpartition(".")
-    if not parent_name or not child_name:
-        return
-
-    parent_module = sys.modules.get(parent_name)
-    if parent_module is not None and getattr(parent_module, child_name, None) is not None:
-        try:
-            delattr(parent_module, child_name)
-        except Exception:
-            pass
-
-
-def _purge_modules(prefixes: Iterable[str]) -> None:
-    names = [
-        name
-        for name in list(sys.modules)
-        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
-    ]
-    for name in sorted(names, key=lambda module_name: module_name.count("."), reverse=True):
-        _unbind_parent_attr(name)
-        sys.modules.pop(name, None)
-
-
-def _snapshot_modules(prefixes: Iterable[str]) -> dict[str, ModuleType]:
-    return {
-        name: module
-        for name, module in list(sys.modules.items())
-        if module is not None
-        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
-    }
-
-
-def _bind_module(name: str, module: ModuleType) -> None:
-    sys.modules[name] = module
-
-    parent_name, _, child_name = name.rpartition(".")
-    if parent_name and child_name:
-        parent_module = sys.modules.get(parent_name)
-        if parent_module is not None:
-            setattr(parent_module, child_name, module)
-
-
-def _restore_modules(snapshot: dict[str, ModuleType], prefixes: Iterable[str]) -> None:
-    _purge_modules(prefixes)
-    for name, module in sorted(snapshot.items(), key=lambda item: item[0].count(".")):
-        _bind_module(name, module)
-
-
-def _reset_route_metrics() -> None:
-    try:
-        from prometheus_client import REGISTRY
-    except Exception:
-        return
-
-    metric_names = {
-        "filter_click",
-        "filter_click_total",
-        "filter_click_created",
-        "search_requests",
-        "search_requests_total",
-        "search_requests_created",
-        "search_zero_results",
-        "search_zero_results_total",
-        "search_zero_results_created",
-        "search_ml_fallback",
-        "search_ml_fallback_total",
-        "search_ml_fallback_created",
-    }
-
-    collectors = {
-        REGISTRY._names_to_collectors[name]  # type: ignore[attr-defined]
-        for name in metric_names
-        if name in REGISTRY._names_to_collectors  # type: ignore[attr-defined]
-    }
-    for collector in collectors:
-        try:
-            REGISTRY.unregister(collector)
-        except Exception:
-            pass
-
-
-def _load_fresh_app():
-    importlib.invalidate_caches()
-    _reset_route_metrics()
-    _purge_modules(["backend.main", "backend.routes"])
-
-    try:
-        module = importlib.import_module("backend.main")
-    except Exception as exc:  # pragma: no cover
-        pytest.skip(f"App unavailable in CI: {exc}")
-
-    return module.app
-
-
-@pytest.fixture(scope="module")
-def fresh_app():
-    module_prefixes = ("backend.main", "backend.routes")
-    prior_environment = os.environ.get("ENVIRONMENT")
-    module_snapshot = _snapshot_modules(module_prefixes)
-    os.environ["ENVIRONMENT"] = "development"
-    try:
-        yield _load_fresh_app()
-    finally:
-        _restore_modules(module_snapshot, module_prefixes)
-        if prior_environment is None:
-            os.environ.pop("ENVIRONMENT", None)
-        else:
-            os.environ["ENVIRONMENT"] = prior_environment
+    _import_error = None
+except Exception as exc:  # pragma: no cover
+    app = None  # type: ignore[assignment]
+    _import_error = exc
 
 
 @pytest.fixture
-def client(fresh_app) -> TestClient:
-    with TestClient(fresh_app) as test_client:
-        yield test_client
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    if app is None:  # pragma: no cover
+        pytest.skip(f"App unavailable in CI: {_import_error}")
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    return TestClient(app)
 
 
 def _assert_keys(payload: dict[str, Any], required_keys: set[str]) -> None:
@@ -143,31 +43,51 @@ def _assert_keys(payload: dict[str, Any], required_keys: set[str]) -> None:
     assert not missing, f"Missing keys: {sorted(missing)}"
 
 
-def _route_debug_context(paths: set[str]) -> str:
-    backend_module = sys.modules.get("backend")
-    backend_main_module = sys.modules.get("backend.main")
+def _load_routes_in_subprocess() -> set[str]:
+    script = textwrap.dedent(
+        """
+        import json
+        import os
 
-    return (
-        f"backend.main_id={id(backend_main_module) if backend_main_module is not None else None}; "
-        f"backend.main_file={getattr(backend_main_module, '__file__', None)}; "
-        f"backend_has_main={hasattr(backend_module, 'main') if backend_module is not None else False}; "
-        f"backend_has_routes={hasattr(backend_module, 'routes') if backend_module is not None else False}; "
-        f"paths={sorted(paths)[:20]}"
+        os.environ["ENVIRONMENT"] = "development"
+
+        from fastapi.routing import APIRoute
+        from backend.main import app
+
+        paths = sorted({r.path for r in app.routes if isinstance(r, APIRoute)})
+        print(json.dumps({
+            "route_count": len(paths),
+            "paths": paths,
+        }))
+        """
     )
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "ENVIRONMENT": "development"},
+        )
+    except subprocess.CalledProcessError as exc:
+        raise AssertionError(
+            "Failed to import backend.main in clean subprocess.\n"
+            f"stdout:\n{exc.stdout}\n"
+            f"stderr:\n{exc.stderr}\n"
+        ) from exc
+
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict)
+    assert isinstance(payload.get("paths"), list)
+    return set(payload["paths"])
 
 
 def test_debug_routes_contains_critical_paths(client: TestClient) -> None:
-    resp = client.get("/debug/routes")
-    assert resp.status_code == 200
-
-    body = resp.json()
-    assert isinstance(body, dict)
-    assert isinstance(body.get("paths"), list)
-
-    paths = set(body["paths"])
+    paths = _load_routes_in_subprocess()
     assert (
         len(paths) >= 20
-    ), f"Unexpectedly low route count: {len(paths)}; {_route_debug_context(paths)}"
+    ), f"Unexpectedly low route count: {len(paths)}; paths={sorted(paths)[:50]}"
     critical = {
         "/",
         "/health",

--- a/backend/tests/test_route_diagnostics.py
+++ b/backend/tests/test_route_diagnostics.py
@@ -69,7 +69,6 @@ def _load_routes_in_subprocess() -> dict[str, Any]:
             payload["backend_import_error"] = traceback.format_exc()
 
         try:
-            from fastapi.routing import APIRoute
             import backend.main as main
 
             payload["backend_main_file"] = getattr(main, "__file__", None)
@@ -85,7 +84,15 @@ def _load_routes_in_subprocess() -> dict[str, Any]:
                 payload[f"has_{name}"] = hasattr(main, name)
 
             app = main.app
-            paths = sorted({r.path for r in app.routes if isinstance(r, APIRoute)})
+            route_details = main._collect_registered_route_details()
+            paths = sorted(
+                {
+                    route["path"]
+                    for route in route_details
+                    if isinstance(route, dict) and isinstance(route.get("path"), str)
+                }
+            )
+            payload["route_detail_count"] = len(route_details)
             payload["route_count"] = len(paths)
             payload["paths"] = paths
         except Exception:

--- a/backend/tests/test_route_diagnostics.py
+++ b/backend/tests/test_route_diagnostics.py
@@ -11,16 +11,84 @@ It is not a full integration suite and should stay fast.
 from __future__ import annotations
 
 import importlib
+import os
 import sys
+from collections.abc import Iterable
+from types import ModuleType
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
 
+def _purge_modules(prefixes: Iterable[str]) -> None:
+    for name in list(sys.modules):
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes):
+            sys.modules.pop(name, None)
+
+
+def _snapshot_modules(prefixes: Iterable[str]) -> dict[str, ModuleType]:
+    return {
+        name: module
+        for name, module in list(sys.modules.items())
+        if module is not None
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
+    }
+
+
+def _bind_module(name: str, module: ModuleType) -> None:
+    sys.modules[name] = module
+
+    parent_name, _, child_name = name.rpartition(".")
+    if parent_name and child_name:
+        parent_module = sys.modules.get(parent_name)
+        if parent_module is not None:
+            setattr(parent_module, child_name, module)
+
+
+def _restore_modules(snapshot: dict[str, ModuleType], prefixes: Iterable[str]) -> None:
+    _purge_modules(prefixes)
+    for name, module in snapshot.items():
+        _bind_module(name, module)
+
+
+def _reset_route_metrics() -> None:
+    try:
+        from prometheus_client import REGISTRY
+    except Exception:
+        return
+
+    metric_names = {
+        "filter_click",
+        "filter_click_total",
+        "filter_click_created",
+        "search_requests",
+        "search_requests_total",
+        "search_requests_created",
+        "search_zero_results",
+        "search_zero_results_total",
+        "search_zero_results_created",
+        "search_ml_fallback",
+        "search_ml_fallback_total",
+        "search_ml_fallback_created",
+    }
+
+    collectors = {
+        REGISTRY._names_to_collectors[name]  # type: ignore[attr-defined]
+        for name in metric_names
+        if name in REGISTRY._names_to_collectors  # type: ignore[attr-defined]
+    }
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
 def _load_fresh_app():
     importlib.invalidate_caches()
-    sys.modules.pop("backend.main", None)
+    _reset_route_metrics()
+    _purge_modules(["backend.main", "backend.routes"])
 
     try:
         module = importlib.import_module("backend.main")
@@ -30,12 +98,25 @@ def _load_fresh_app():
     return module.app
 
 
-@pytest.fixture
-def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    # Keep diagnostics routes visible.
-    monkeypatch.setenv("ENVIRONMENT", "development")
+@pytest.fixture(scope="module")
+def fresh_app():
+    module_prefixes = ("backend.main", "backend.routes")
+    prior_environment = os.environ.get("ENVIRONMENT")
+    module_snapshot = _snapshot_modules(module_prefixes)
+    os.environ["ENVIRONMENT"] = "development"
+    try:
+        yield _load_fresh_app()
+    finally:
+        _restore_modules(module_snapshot, module_prefixes)
+        if prior_environment is None:
+            os.environ.pop("ENVIRONMENT", None)
+        else:
+            os.environ["ENVIRONMENT"] = prior_environment
 
-    with TestClient(_load_fresh_app()) as test_client:
+
+@pytest.fixture
+def client(fresh_app) -> TestClient:
+    with TestClient(fresh_app) as test_client:
         yield test_client
 
 
@@ -53,6 +134,7 @@ def test_debug_routes_contains_critical_paths(client: TestClient) -> None:
     assert isinstance(body.get("paths"), list)
 
     paths = set(body["paths"])
+    assert len(paths) >= 20, f"Unexpectedly low route count: {len(paths)}; paths={sorted(paths)}"
     critical = {
         "/",
         "/health",

--- a/backend/tests/test_route_diagnostics.py
+++ b/backend/tests/test_route_diagnostics.py
@@ -10,28 +10,33 @@ It is not a full integration suite and should stay fast.
 
 from __future__ import annotations
 
+import importlib
+import sys
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
-try:
-    from backend.main import app  # type: ignore
 
-    _import_error = None
-except Exception as e:  # pragma: no cover
-    app = None  # type: ignore[assignment]
-    _import_error = e
+def _load_fresh_app():
+    importlib.invalidate_caches()
+    sys.modules.pop("backend.main", None)
+
+    try:
+        module = importlib.import_module("backend.main")
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"App unavailable in CI: {exc}")
+
+    return module.app
 
 
 @pytest.fixture
 def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    if app is None:  # pragma: no cover
-        pytest.skip(f"App unavailable in CI: {_import_error}")
-
     # Keep diagnostics routes visible.
     monkeypatch.setenv("ENVIRONMENT", "development")
-    return TestClient(app)
+
+    with TestClient(_load_fresh_app()) as test_client:
+        yield test_client
 
 
 def _assert_keys(payload: dict[str, Any], required_keys: set[str]) -> None:

--- a/backend/tests/test_route_diagnostics.py
+++ b/backend/tests/test_route_diagnostics.py
@@ -43,22 +43,55 @@ def _assert_keys(payload: dict[str, Any], required_keys: set[str]) -> None:
     assert not missing, f"Missing keys: {sorted(missing)}"
 
 
-def _load_routes_in_subprocess() -> set[str]:
+def _load_routes_in_subprocess() -> dict[str, Any]:
     script = textwrap.dedent(
         """
         import json
         import os
+        import sys
+        import traceback
 
-        os.environ["ENVIRONMENT"] = "development"
+        payload = {
+            "cwd": os.getcwd(),
+            "python": sys.executable,
+            "sys_path_first": sys.path[:10],
+            "ENVIRONMENT": os.environ.get("ENVIRONMENT"),
+            "CI": os.environ.get("CI"),
+            "PYTHONPATH": os.environ.get("PYTHONPATH"),
+        }
 
-        from fastapi.routing import APIRoute
-        from backend.main import app
+        try:
+            import backend
 
-        paths = sorted({r.path for r in app.routes if isinstance(r, APIRoute)})
-        print(json.dumps({
-            "route_count": len(paths),
-            "paths": paths,
-        }))
+            payload["backend_file"] = getattr(backend, "__file__", None)
+            payload["backend_path"] = list(getattr(backend, "__path__", []))
+        except Exception:
+            payload["backend_import_error"] = traceback.format_exc()
+
+        try:
+            from fastapi.routing import APIRoute
+            import backend.main as main
+
+            payload["backend_main_file"] = getattr(main, "__file__", None)
+            payload["backend_main_id"] = id(main)
+            for name in [
+                "ai_router",
+                "properties_router",
+                "save_deal_router",
+                "area_intel_router",
+                "comps_router",
+                "gpt_router",
+            ]:
+                payload[f"has_{name}"] = hasattr(main, name)
+
+            app = main.app
+            paths = sorted({r.path for r in app.routes if isinstance(r, APIRoute)})
+            payload["route_count"] = len(paths)
+            payload["paths"] = paths
+        except Exception:
+            payload["main_import_error"] = traceback.format_exc()
+
+        print(json.dumps(payload))
         """
     )
 
@@ -80,14 +113,13 @@ def _load_routes_in_subprocess() -> set[str]:
     payload = json.loads(result.stdout)
     assert isinstance(payload, dict)
     assert isinstance(payload.get("paths"), list)
-    return set(payload["paths"])
+    return payload
 
 
 def test_debug_routes_contains_critical_paths(client: TestClient) -> None:
-    paths = _load_routes_in_subprocess()
-    assert (
-        len(paths) >= 20
-    ), f"Unexpectedly low route count: {len(paths)}; paths={sorted(paths)[:50]}"
+    payload = _load_routes_in_subprocess()
+    paths = set(payload["paths"])
+    assert len(paths) >= 20, json.dumps(payload, indent=2, sort_keys=True)
     critical = {
         "/",
         "/health",

--- a/backend/tests/test_user_submitted_property.py
+++ b/backend/tests/test_user_submitted_property.py
@@ -49,6 +49,27 @@ class _FakeInsertQuery:
         return _Result([row])
 
 
+class _FakePropertySelectQuery:
+    def __init__(self, row: dict[str, object]):
+        self.row = row
+        self.eq_filters: dict[str, str] = {}
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, key: str, value: str):
+        self.eq_filters[key] = value
+        return self
+
+    def maybe_single(self):
+        return self
+
+    def execute(self):
+        if self.eq_filters.get("id") == str(self.row.get("id")):
+            return _Result(dict(self.row))
+        return _Result(None)
+
+
 class _FakeSupabase:
     def __init__(self):
         self.query = _FakeInsertQuery()
@@ -56,6 +77,15 @@ class _FakeSupabase:
     def table(self, name: str):
         assert name == "properties"
         return self.query
+
+
+class _FakeSupabaseForGet:
+    def __init__(self, row: dict[str, object]):
+        self.row = row
+
+    def table(self, name: str):
+        assert name == "properties"
+        return _FakePropertySelectQuery(self.row)
 
 
 def test_create_user_submitted_property_uses_reference_url_only(
@@ -94,3 +124,59 @@ def test_create_user_submitted_property_uses_reference_url_only(
     assert payload["source_url"] == "https://example.com/listing/42"
     assert payload["data"]["user_provided_reference_only"] is True
     assert payload["data"]["rent_monthly"] == 1350
+
+
+def test_create_user_submitted_property_does_not_fetch_reference_url(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import backend.routes.properties_routes as property_routes
+
+    fake = _FakeSupabase()
+    monkeypatch.setattr(property_routes, "_get_supabase", lambda: fake, raising=True)
+
+    class _FailIfUsedHttpClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("Reference URL must not be fetched in user-submitted flow")
+
+    monkeypatch.setattr(property_routes.httpx, "Client", _FailIfUsedHttpClient, raising=True)
+
+    response = client.post(
+        "/properties/user-submitted",
+        headers=_trusted_headers(),
+        json={
+            "source_url": "https://example.com/listing/99",
+            "title": "No fetch expected",
+            "location": "Leeds",
+            "price": 199000,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json().get("ok") is True
+
+
+def test_get_property_allows_direct_access_for_user_submitted_row(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import backend.routes.properties_routes as property_routes
+
+    manual_row = {
+        "id": "prop_user_submitted",
+        "title": "Manual row",
+        "location": "Manchester",
+        "source": "user_submitted",
+        "price": 215000,
+    }
+    monkeypatch.setattr(
+        property_routes,
+        "_get_supabase",
+        lambda: _FakeSupabaseForGet(manual_row),
+        raising=True,
+    )
+
+    response = client.get("/properties/prop_user_submitted")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "prop_user_submitted"
+    assert body["source"] == "user_submitted"

--- a/frontend/__tests__/PropertyCard.source-badge.spec.tsx
+++ b/frontend/__tests__/PropertyCard.source-badge.spec.tsx
@@ -97,6 +97,74 @@ describe('PropertyCard source badge', () => {
     expect(badge).toHaveClass('bg-rose-100');
   });
 
+  it('renders user_submitted source as Manual deal with neutral badge styling', () => {
+    render(
+      <PropertyCard
+        p={{
+          id: 'manual-1',
+          title: 'Manual intake',
+          source: 'user_submitted',
+          location: 'Leeds',
+          price: 210000,
+        }}
+      />,
+    );
+
+    const badge = screen.getByText('Manual deal');
+    expect(badge).toHaveClass('bg-slate-100');
+  });
+
+  it('shows Details not provided when bedrooms and bathrooms are both missing', () => {
+    render(
+      <PropertyCard
+        p={{
+          id: 'manual-2',
+          title: 'Manual intake no details',
+          source: 'user_submitted',
+          location: 'Leeds',
+          price: 210000,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Details not provided')).toBeInTheDocument();
+    expect(screen.queryByText(/— bd · — ba/i)).not.toBeInTheDocument();
+  });
+
+  it('shows only provided bed or bath values when one field is missing', () => {
+    const { rerender } = render(
+      <PropertyCard
+        p={{
+          id: 'manual-3',
+          title: 'Bedrooms only',
+          source: 'user_submitted',
+          location: 'Leeds',
+          price: 210000,
+          bedrooms: 3,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('3 bd')).toBeInTheDocument();
+    expect(screen.queryByText(/ba$/i)).not.toBeInTheDocument();
+
+    rerender(
+      <PropertyCard
+        p={{
+          id: 'manual-4',
+          title: 'Bathrooms only',
+          source: 'user_submitted',
+          location: 'Leeds',
+          price: 210000,
+          bathrooms: 2,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('2 ba')).toBeInTheDocument();
+    expect(screen.queryByText(/bd$/i)).not.toBeInTheDocument();
+  });
+
   it('renders trust badge chips from badges metadata', () => {
     render(
       <PropertyCard

--- a/frontend/__tests__/listings-page.regression.spec.tsx
+++ b/frontend/__tests__/listings-page.regression.spec.tsx
@@ -171,4 +171,37 @@ describe('Listings page regressions', () => {
     expect(requestedUrl).toContain('high_confidence_top_deals=1');
     expect(screen.queryByText('No high-confidence Top Deals surfaced in this search yet.')).not.toBeInTheDocument();
   });
+
+  it('hides user_submitted rows from the public listings grid by default', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            id: 'manual-1',
+            title: 'Manual Uploaded Deal',
+            source: 'user_submitted',
+            price: 170000,
+            created_at: '2026-06-25T00:00:00Z',
+          },
+          {
+            id: 'public-1',
+            title: 'Visible Rightmove',
+            source: 'rightmove',
+            price: 150000,
+            created_at: '2026-06-25T00:00:00Z',
+          },
+        ],
+        total: 2,
+        limit: 25,
+        offset: 0,
+        has_more: false,
+      }),
+    });
+
+    render(<ListingsPage />);
+
+    expect(await screen.findByText('Visible Rightmove')).toBeInTheDocument();
+    expect(screen.queryByText('Manual Uploaded Deal')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/app/analyse/page.tsx
+++ b/frontend/app/analyse/page.tsx
@@ -148,7 +148,7 @@ export default function AnalysePage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
-      <section className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+      <section className="mx-auto max-w-7xl px-4 py-12 pb-32 sm:px-6 lg:px-8 lg:py-16 lg:pb-16">
         <div className="grid gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-start">
           <div className="space-y-6">
             <div className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-sky-50 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-sky-700 dark:border-sky-900/60 dark:bg-sky-950/30 dark:text-sky-200">

--- a/frontend/app/api/saved-deals/route.ts
+++ b/frontend/app/api/saved-deals/route.ts
@@ -86,7 +86,7 @@ function mergeMissing(target: Record<string, any>, source: Record<string, any>, 
   }
 }
 
-export async function GET(req: Request) {
+export async function GET(req?: Request) {
   const userId = await getSafeUserId();
   if (!userId) {
     return NextResponse.json(
@@ -96,7 +96,8 @@ export async function GET(req: Request) {
   }
 
   try {
-    const url = new URL(req.url || 'http://localhost/api/saved-deals');
+    // Unit tests call GET() directly without a Request; Next.js provides Request at runtime.
+    const url = new URL(req?.url || 'http://localhost/api/saved-deals');
     const propertyIdFilter = url.searchParams.get('property_id')?.trim();
 
     const dealsRes = await backendFetch(`/saved-deals?user_id=${encodeURIComponent(userId)}`, {

--- a/frontend/app/listings/page.tsx
+++ b/frontend/app/listings/page.tsx
@@ -1996,14 +1996,9 @@ function ListingsInner() {
                 {sort === 'top_deals' && watchlistTopDeals.length > 0 ? (
                   <p className="mt-2 text-sm text-slate-500">{watchlistTopDeals.length} watchlist leads are available, but they do not meet Top Deal confidence yet.</p>
                 ) : null}
-                <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-                  <button onClick={resetFilters} className="btn-primary">
-                    Clear Filters
-                  </button>
-                  <Link href="/analyse" className="rounded-md border border-slate-300 dark:border-slate-700 px-5 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors inline-flex">
-                    Analyse your own deal instead
-                  </Link>
-                </div>
+                <button onClick={resetFilters} className="btn-primary mt-4">
+                  Clear Filters
+                </button>
               </div>
             ) : (
               <>
@@ -2074,14 +2069,9 @@ function ListingsInner() {
                   <p className="text-xl text-slate-600 dark:text-slate-400">
                     {sort === 'top_deals' ? 'No high-confidence Top Deals surfaced in this search yet.' : 'No properties match these filters.'}
                   </p>
-                  <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-                    <button onClick={resetFilters} className="btn-primary">
-                      Clear Filters
-                    </button>
-                    <Link href="/analyse" className="rounded-md border border-slate-300 dark:border-slate-700 px-5 py-2 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors inline-flex">
-                      Analyse your own deal instead
-                    </Link>
-                  </div>
+                  <button onClick={resetFilters} className="btn-primary mt-4">
+                    Clear Filters
+                  </button>
                 </div>
               ) : (
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/frontend/app/listings/page.tsx
+++ b/frontend/app/listings/page.tsx
@@ -876,7 +876,7 @@ function ListingsInner() {
         if (maxP !== undefined) params.set('max', String(maxP));
         if (beds !== undefined) params.set('beds', String(beds));
         if (baths !== undefined) params.set('baths', String(baths));
-        // Investment type filtering can be inconsistent in scraped datasets.
+        // Investment type filtering can be inconsistent in imported listing datasets.
         // We keep the UI chips, but apply them client-side so they never feel “broken”.
         params.set('sort', sort);
         params.set('limit', String(limit));
@@ -1230,7 +1230,7 @@ function ListingsInner() {
       const data = await res.json().catch(() => ({}));
 
       if (!res.ok) {
-        throw new Error(data?.detail || data?.error || `Scrape failed (${res.status})`);
+        throw new Error(data?.detail || data?.error || `Import failed (${res.status})`);
       }
 
       const c =
@@ -1239,12 +1239,12 @@ function ListingsInner() {
           : typeof data?.count === 'number'
             ? data.count
             : 0;
-      setScrapeMsg(`Scrape complete: imported ${c} listings for “${loc}”. Refreshing…`);
+      setScrapeMsg(`Admin import complete: imported ${c} listings for “${loc}”. Refreshing…`);
 
       // refresh the listings fetch
       setRefreshNonce((n) => n + 1);
     } catch (e: any) {
-      setScrapeErr(e?.message || 'Scrape failed');
+      setScrapeErr(e?.message || 'Import failed');
     } finally {
       setScrapeLoading(false);
     }
@@ -1843,9 +1843,9 @@ function ListingsInner() {
                     onClick={runScrape}
                     className="h-10 px-3 md:px-4 rounded-lg border border-brand-300 dark:border-brand-700 bg-white dark:bg-slate-800 text-brand-700 dark:text-brand-300 hover:bg-brand-50 dark:hover:bg-brand-900/20 font-semibold transition-all duration-200"
                     disabled={scrapeLoading}
-                    title="Admin: run scrapers and import fresh listings"
+                    title="Admin: run listing import and refresh inventory"
                   >
-                  {scrapeLoading ? 'Running…' : 'Run Scrape'}
+                  {scrapeLoading ? 'Running…' : 'Run Import'}
                   </button>
                 )}
               </div>

--- a/frontend/app/listings/page.tsx
+++ b/frontend/app/listings/page.tsx
@@ -1077,11 +1077,21 @@ function ListingsInner() {
       .replace(/[-_]/g, '');
   }, []);
 
+  const publicRows = useMemo(
+    () => rows.filter((p) => String(p.source ?? '').trim().toLowerCase() !== 'user_submitted'),
+    [rows],
+  );
+
+  const publicMapRows = useMemo(
+    () => (mapRows ?? []).filter((p) => String(p.source ?? '').trim().toLowerCase() !== 'user_submitted'),
+    [mapRows],
+  );
+
   const typeFilteredRows = useMemo(() => {
-    if (!investmentTypeUrl) return rows;
+    if (!investmentTypeUrl) return publicRows;
     const selected = normInv(investmentTypeUrl);
-    return rows.filter((p) => normInv(p.investment_type) === selected);
-  }, [investmentTypeUrl, normInv, rows]);
+    return publicRows.filter((p) => normInv(p.investment_type) === selected);
+  }, [investmentTypeUrl, normInv, publicRows]);
 
   const highConfidenceTopDeals = useMemo(
     () => typeFilteredRows.filter((p) => ['prime', 'strong'].includes(String(p.top_deal_tier || p.top_deal?.tier || '').toLowerCase())),
@@ -1095,10 +1105,10 @@ function ListingsInner() {
 
   const typeFilteredMapRows = useMemo(() => {
     if (!mapRows) return typeFilteredRows;
-    if (!investmentTypeUrl) return mapRows;
+    if (!investmentTypeUrl) return publicMapRows;
     const selected = normInv(investmentTypeUrl);
-    return mapRows.filter((p) => normInv(p.investment_type) === selected);
-  }, [investmentTypeUrl, mapRows, normInv, typeFilteredRows]);
+    return publicMapRows.filter((p) => normInv(p.investment_type) === selected);
+  }, [investmentTypeUrl, mapRows, normInv, publicMapRows, typeFilteredRows]);
 
   // ✅ robust points creation (no falsy checks, reject invalid/null-island)
   const points = useMemo(() => {

--- a/frontend/app/property/[id]/page.tsx
+++ b/frontend/app/property/[id]/page.tsx
@@ -430,7 +430,7 @@ export default function PropertyDetailsPage() {
         aiScore={aiScore}
       />
 
-      <div className="max-w-7xl mx-auto px-4 py-8 lg:pr-64">{/* Add right padding on desktop for floating sidebar */}
+      <div className="max-w-7xl mx-auto px-4 py-8 pb-28 lg:pr-64 lg:pb-8">{/* Add right padding on desktop for floating sidebar */}
         {/* Image-first (focal) carousel + details */}
         <div className="card mb-6 overflow-hidden !p-0">
           <ImageGallery

--- a/frontend/components/PropertyCard.tsx
+++ b/frontend/components/PropertyCard.tsx
@@ -115,6 +115,7 @@ function formatSourceBadge(source: string | null | undefined): string {
   const raw = (source ?? '').trim();
   const normalized = raw.toLowerCase();
 
+  if (normalized === 'user_submitted') return 'Manual deal';
   if (normalized === 'zoopla') return 'Zoopla';
   if (normalized === 'rightmove') return 'Rightmove';
   if (normalized === 'onthemarket' || normalized === 'otm') return 'OTM';
@@ -127,6 +128,10 @@ function formatSourceBadge(source: string | null | undefined): string {
 
 function getSourceBadgeClasses(source: string | null | undefined): string {
   const normalized = (source ?? '').trim().toLowerCase();
+
+  if (normalized === 'user_submitted') {
+    return 'bg-slate-100 text-slate-700 border border-slate-300 dark:bg-slate-800/70 dark:text-slate-100 dark:border-slate-600';
+  }
 
   // Requested brand colors:
   // - Zoopla: purple
@@ -619,6 +624,19 @@ export default function PropertyCard({
 
   const sourceBadgeText = useMemo(() => formatSourceBadge(p.source), [p.source]);
   const sourceBadgeClasses = useMemo(() => getSourceBadgeClasses(p.source), [p.source]);
+  const bedsBathsDisplay = useMemo(() => {
+    const hasBeds = typeof p.bedrooms === 'number' && Number.isFinite(p.bedrooms);
+    const hasBaths = typeof p.bathrooms === 'number' && Number.isFinite(p.bathrooms);
+
+    if (!hasBeds && !hasBaths) {
+      return { text: 'Details not provided', hasValues: false };
+    }
+
+    const parts: string[] = [];
+    if (hasBeds) parts.push(`${p.bedrooms} bd`);
+    if (hasBaths) parts.push(`${p.bathrooms} ba`);
+    return { text: parts.join(' · '), hasValues: true };
+  }, [p.bathrooms, p.bedrooms]);
 
   const verdict = useMemo(() => buildVerdict(p), [p]);
   const whySurfacedLabel = useMemo(() => {
@@ -805,8 +823,8 @@ export default function PropertyCard({
           <div className="flex items-center justify-between gap-2">
             <span className="text-base font-black leading-none text-slate-950 dark:text-white">{priceText}</span>
             <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-white px-2 py-1 text-[11px] font-bold text-slate-700 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:text-slate-200 dark:ring-slate-700">
-              <FiHome className="h-3.5 w-3.5 text-brand-500" aria-hidden="true" />
-              {p.bedrooms ?? '—'} bd · {p.bathrooms ?? '—'} ba
+              {bedsBathsDisplay.hasValues ? <FiHome className="h-3.5 w-3.5 text-brand-500" aria-hidden="true" /> : null}
+              {bedsBathsDisplay.text}
             </span>
           </div>
           <div className="mt-1.5 flex items-center gap-1.5 text-xs font-semibold text-slate-600 dark:text-slate-400">

--- a/frontend/components/__tests__/WhySurfaced.spec.tsx
+++ b/frontend/components/__tests__/WhySurfaced.spec.tsx
@@ -31,6 +31,7 @@ describe('WhySurfaced', () => {
     expect(screen.getAllByText(/Price reduction found/i).length).toBeGreaterThan(0);
     expect(screen.getByText('Comps evidence')).toBeInTheDocument();
     expect(screen.getByText(/Sold comps available/i)).toBeInTheDocument();
+    expect(screen.getByText(/Discovery score ranks available deal-discovery signals, not investment suitability/i)).toBeInTheDocument();
   });
 
   it('does not render unsupported BMV claims without comps evidence', () => {

--- a/frontend/components/property_details/OfferIntelligence.spec.tsx
+++ b/frontend/components/property_details/OfferIntelligence.spec.tsx
@@ -52,6 +52,7 @@ describe('OfferIntelligence', () => {
     );
 
     expect(screen.getByText('Estimate/missing — not treated as a rent comp')).toBeInTheDocument();
-    expect(screen.getByText('Insufficient rent evidence to calculate a reliable offer target.')).toBeInTheDocument();
+    expect(screen.getByText('Add verified rent evidence to unlock a reliable target offer and walk-away price.')).toBeInTheDocument();
+    expect(screen.getByText('Manual deal records can still be analysed, but target offer calculations are withheld until rent/comparable evidence is available.')).toBeInTheDocument();
   });
 });

--- a/frontend/components/property_details/OfferIntelligence.tsx
+++ b/frontend/components/property_details/OfferIntelligence.tsx
@@ -15,6 +15,13 @@ function fmtPct(n: unknown): string {
 }
 
 export default function OfferIntelligence({ intel, loading = false }: { intel: InvestorIntel | null; loading?: boolean }) {
+  const hasVerifiedRentEvidence = Boolean(intel?.rent_evidence?.is_real_rent_evidence);
+  const rawConclusion = typeof intel?.conclusion === 'string' ? intel.conclusion.trim() : '';
+  const conclusionText =
+    !hasVerifiedRentEvidence && /insufficient rent evidence/i.test(rawConclusion)
+      ? 'Add verified rent evidence to unlock a reliable target offer and walk-away price.'
+      : rawConclusion;
+
   const body = loading ? (
     <div className="animate-pulse space-y-3">
       <div className="h-20 rounded-2xl bg-slate-200 dark:bg-slate-800" />
@@ -67,7 +74,12 @@ export default function OfferIntelligence({ intel, loading = false }: { intel: I
 
       <div className="rounded-2xl border border-brand-200 bg-brand-50 p-4 text-sm dark:border-brand-900/60 dark:bg-brand-950/20">
         <div className="font-black text-brand-900 dark:text-brand-100">Conclusion</div>
-        <p className="mt-1 text-brand-800 dark:text-brand-200">{intel.conclusion}</p>
+        <p className="mt-1 text-brand-800 dark:text-brand-200">{conclusionText}</p>
+        {!hasVerifiedRentEvidence ? (
+          <p className="mt-2 text-brand-700 dark:text-brand-200/90">
+            Manual deal records can still be analysed, but target offer calculations are withheld until rent/comparable evidence is available.
+          </p>
+        ) : null}
       </div>
       <div className="text-xs text-slate-500 dark:text-slate-400">
         Comparable median: {fmtGBP(intel.sold_comp_benchmark?.median_similar_price)} · Difference: {fmtGBP(Math.abs(Number(intel.sold_comp_benchmark?.subject_vs_median_amount || 0)))} ({fmtPct(intel.sold_comp_benchmark?.subject_vs_median_pct)}) · {intel.sold_comp_benchmark?.benchmark_confidence || 'weak'} comp set

--- a/frontend/components/property_details/WhySurfaced.tsx
+++ b/frontend/components/property_details/WhySurfaced.tsx
@@ -191,7 +191,7 @@ export default function WhySurfaced({ property }: { property: WhySurfacedPropert
       </div>
 
       <InfoDisclaimer className="mt-3" label="Discovery score disclaimer">
-        Discovery score ranks scrape-discovery signals, not investment suitability. A high discovery score still requires full due diligence.
+        Discovery score ranks available deal-discovery signals, not investment suitability. A high discovery score still requires full due diligence.
       </InfoDisclaimer>
     </section>
   );

--- a/frontend/lib/legalCopy.ts
+++ b/frontend/lib/legalCopy.ts
@@ -10,7 +10,7 @@ export const AI_DISCLAIMER =
   'AI-generated content may be incomplete or inaccurate. Treat summaries and strategy suggestions as a starting point for review, not as advice or a recommendation.';
 
 export const DATA_ACCURACY_DISCLAIMER =
-  'Data may come from third-party sources, cached records, scraped listings, public datasets, user inputs or derived estimates. Availability and accuracy can vary by property and area.';
+  'Data may come from third-party sources, cached records, aggregated listing records, public datasets, user inputs or derived estimates. Availability and accuracy can vary by property and area.';
 
 export const AREA_INTEL_DISCLAIMER =
   'Area intelligence is indicative and depends on available local data. Missing or cached data should not be treated as evidence that an area is low risk or high opportunity.';

--- a/frontend/lib/propertyDealActions.ts
+++ b/frontend/lib/propertyDealActions.ts
@@ -60,6 +60,7 @@ export function getOriginalListingUrl(property: PropertyLike): string | null {
 }
 
 export function getSourceLabel(property: PropertyLike): string {
+  if (textIncludes(property, /user_submitted|manual[_\s-]?deal/)) return 'Manual deal';
   if (textIncludes(property, /rightmove/)) return 'Rightmove';
   if (textIncludes(property, /zoopla/)) return 'Zoopla';
   if (textIncludes(property, /onthemarket|on the market|\botm\b/)) return 'OnTheMarket';


### PR DESCRIPTION
## Summary
- Removed public scrape-discovery wording from investor-facing UI copy.
- Changed user_submitted source display to Manual deal.
- Prevented manual deals appearing in public listings by default.
- Improved missing beds/baths display on property cards.
- Improved Offer Intelligence missing-evidence copy for rent/comps-gated target offers.
- Added safe bottom spacing on analyse and property detail views to reduce Ask AI floating button overlap risk.
- Confirmed Sprint 2 implementation was not started.

## Scope Notes
- No Sprint 2 paid gating work started.
- No Stripe or pricing implementation changes.
- Kept the legal-safe sentence on /analyse: "PropNexus does not scrape or copy third-party listing pages in this flow."
- User-submitted deals are excluded from public Listings only; they remain accessible via direct /property/{id} and are preserved for creator-owned/future My Analysed Deals/Saved Deals flows.

## Changes
- Public copy
  - Updated discovery disclaimer wording to deal-discovery phrasing in Why Surfaced.
  - Updated shared legal copy to remove "scraped listings" phrasing from user-facing disclaimer text.
- Manual deal source label
  - Property card source badge maps user_submitted to Manual deal with neutral styling.
  - Shared source label helper also maps user_submitted/manual deal values to Manual deal.
- Listings pollution prevention
  - Backend `/properties` now excludes `source=user_submitted` by default unless an explicit source filter is requested.
  - Frontend listings view model also hides user_submitted rows by default as a safety guard.
- Missing beds/baths polish
  - Replaced "— bd · — ba" with "Details not provided" when both are missing.
  - Shows only the available value when only beds or only baths is provided.
- Offer Intelligence missing evidence copy
  - Replaced insufficient-rent fallback text with:
    - "Add verified rent evidence to unlock a reliable target offer and walk-away price."
  - Added helper text:
    - "Manual deal records can still be analysed, but target offer calculations are withheld until rent/comparable evidence is available."
- Ask AI floating button spacing hardening
  - Added extra bottom padding on /analyse and property detail pages to keep submit/notes/key content clear on smaller viewports.

## Tests
- Targeted tests:
  - `npm --prefix frontend run test -- --runTestsByPath __tests__/PropertyCard.source-badge.spec.tsx __tests__/listings-page.regression.spec.tsx components/__tests__/WhySurfaced.spec.tsx components/property_details/OfferIntelligence.spec.tsx`
- Lint:
  - `npm --prefix frontend run lint`
- Build:
  - `NEXT_TELEMETRY_DISABLED=1 NEXT_PRIVATE_BUILD_WORKER=1 npm --prefix frontend run build`

All above checks passed locally.
