### PR TITLE
feat(monetisation): add Sprint 2 paid Deal Pack gating

### DIFF
--- a/docs/sprint-2-paid-gating.md
+++ b/docs/sprint-2-paid-gating.md
@@ -1,0 +1,99 @@
+# Sprint 2 Paid Deal Pack Gating
+
+Sprint 2 adds the first paid gating layer for Deal Desk outputs without changing the backend subscription schema. The backend still stores `free`, `pro`, and `investor`. The frontend remaps those plans to launch-facing tiers.
+
+## Launch pricing
+
+- Free: `£0/month`
+- Investor Starter: `£9/month` launch price, later `£19/month`
+- Investor Pro: `£19/month` launch price, later `£39/month`
+- Sourcer Pro: `£39/month` launch price, later `£79/month` and still coming soon
+
+Founding member copy:
+
+> Founding member pricing available for early users. Prices may increase as PropNexus adds more data, Deal Pack features and integrations.
+
+## Plan mapping
+
+- Backend `free` -> launch `Free`
+- Backend `pro` -> launch `Investor Starter`
+- Backend `investor` -> launch `Investor Pro`
+
+This keeps Stripe webhook and backend plan persistence unchanged for Sprint 2.
+
+## Feature gates
+
+### Free
+
+- Basic pricing page access
+- Basic yield and evidence preview in Offer Intelligence
+- Deal Pack preview page remains reachable by direct route
+- No full offer range
+- No PDF export
+- No full Deal Pack
+
+### Investor Starter
+
+- Full Deal Label naming in the launch copy layer
+- Indicative offer range when rent evidence is strong enough
+- Saved deals workspace
+- No PDF export
+- No full Deal Pack printable output
+- No finance stress-test
+
+### Investor Pro
+
+- Full offer range
+- Full Deal Pack page output
+- PDF export route access
+- Finance stress-test positioning in plan copy
+- Full printable underwriting workflow
+
+### Sourcer Pro
+
+- Pricing card only
+- No checkout implementation shipped in Sprint 2
+- No branded sourcer reports shipped in Sprint 2
+
+## Required Stripe env vars
+
+Frontend launch pricing reads only public Stripe ids:
+
+- `NEXT_PUBLIC_STRIPE_PRICE_PRO`
+- `NEXT_PUBLIC_STRIPE_PRODUCT_PRO`
+- `NEXT_PUBLIC_STRIPE_PRICE_INVESTOR`
+- `NEXT_PUBLIC_STRIPE_PRODUCT_INVESTOR`
+- `NEXT_PUBLIC_STRIPE_PRICE_SOURCER_PRO` optional for future use
+- `NEXT_PUBLIC_STRIPE_PRODUCT_SOURCER_PRO` optional for future use
+
+Backend checkout and webhook behavior still depend on the existing server env vars:
+
+- `STRIPE_PRICE_PRO`
+- `STRIPE_PRODUCT_PRO`
+- `STRIPE_PRICE_INVESTOR`
+- `STRIPE_PRODUCT_INVESTOR`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_SUCCESS_URL`
+- `STRIPE_CANCEL_URL`
+- `STRIPE_PORTAL_RETURN_URL`
+
+## Notes
+
+- `/property/[id]/deal-pack` now shows a preview for non-Pro users instead of failing closed.
+- `/api/property-pdf/[id]` is server-gated and returns `403 upgrade_required` unless the user has Investor Pro entitlements.
+- Manual deals remain reachable by direct property URL.
+- This sprint does not change the `/analyse` legal sentence.
+
+## Deferred work
+
+### Sprint 2B
+
+- Usage credits
+- Metering and quota enforcement
+- Any credit wallet or balance UX
+
+### Sprint 3
+
+- Sourcer Pro branded reports
+- Client-ready sourcer exports
+- Sourcer branding workflows

--- a/frontend/__tests__/api-property-pdf-route.spec.ts
+++ b/frontend/__tests__/api-property-pdf-route.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals
 const mockFetchPropertyById = jest.fn();
 const mockGetOptionalClerkUserId = jest.fn();
 const mockRenderDealPackPdfFromUrl = jest.fn();
+const mockGetServerEntitlements = jest.fn();
 
 jest.mock('@/lib/server/propertyData', () => ({
   fetchPropertyById: (...args: unknown[]) => mockFetchPropertyById(...args),
@@ -15,6 +16,10 @@ jest.mock('@/lib/server/propertyPdfRenderer', () => ({
   renderDealPackPdfFromUrl: (...args: unknown[]) => mockRenderDealPackPdfFromUrl(...args),
 }));
 
+jest.mock('@/lib/server/userPlan', () => ({
+  getServerEntitlements: (...args: unknown[]) => mockGetServerEntitlements(...args),
+}));
+
 describe('/api/property-pdf/[id]', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -22,6 +27,7 @@ describe('/api/property-pdf/[id]', () => {
     process.env.NEXT_PUBLIC_FEATURE_DEAL_PACK = 'true';
     delete process.env.NEXT_PUBLIC_FEATURE_PROPERTY_EXPORTS;
     mockGetOptionalClerkUserId.mockResolvedValue('user_123');
+    mockGetServerEntitlements.mockResolvedValue({ hasPdfExport: true });
     mockFetchPropertyById.mockResolvedValue({
       id: 'prop-123',
       title: 'Central Flat',
@@ -76,5 +82,18 @@ describe('/api/property-pdf/[id]', () => {
     expect(await res.json()).toEqual({ error: 'not_found' });
     expect(mockFetchPropertyById).not.toHaveBeenCalled();
     expect(mockRenderDealPackPdfFromUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the signed-in plan does not include PDF export', async () => {
+    mockGetServerEntitlements.mockResolvedValue({ hasPdfExport: false });
+    const { GET } = await import('@/app/api/property-pdf/[id]/route');
+
+    const res = await GET(new Request('https://app.example/api/property-pdf/prop-123'), {
+      params: Promise.resolve({ id: 'prop-123' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'upgrade_required', required_plan: 'investor_pro' });
+    expect(mockFetchPropertyById).not.toHaveBeenCalled();
   });
 });

--- a/frontend/__tests__/lib/planPermissions.spec.tsx
+++ b/frontend/__tests__/lib/planPermissions.spec.tsx
@@ -32,34 +32,34 @@ describe('planPermissions', () => {
   });
 
   describe('getPlanLabel', () => {
-    it('returns correctly capitalized plan labels', () => {
+    it('returns launch-plan labels for the existing backend tiers', () => {
       expect(getPlanLabel('free')).toBe('Free');
-      expect(getPlanLabel('pro')).toBe('Pro');
-      expect(getPlanLabel('investor')).toBe('Investor');
+      expect(getPlanLabel('pro')).toBe('Investor Starter');
+      expect(getPlanLabel('investor')).toBe('Investor Pro');
     });
   });
 
   describe('getPlanArticle', () => {
-    it('returns correct article for each plan', () => {
+    it('returns an article based on the public plan label', () => {
       expect(getPlanArticle('free')).toBe('a');
-      expect(getPlanArticle('pro')).toBe('a');
+      expect(getPlanArticle('pro')).toBe('an');
       expect(getPlanArticle('investor')).toBe('an');
     });
   });
 
   describe('getUpgradeMessage', () => {
-    it('generates correct upgrade messages', () => {
-      expect(getUpgradeMessage('free')).toBe('This feature requires a Free plan.');
-      expect(getUpgradeMessage('pro')).toBe('This feature requires a Pro plan.');
-      expect(getUpgradeMessage('investor')).toBe('This feature requires an Investor plan.');
+    it('generates launch-tier upgrade messages', () => {
+      expect(getUpgradeMessage('free')).toBe('Upgrade to Free to unlock this feature.');
+      expect(getUpgradeMessage('pro')).toBe('Upgrade to Investor Starter to unlock this feature.');
+      expect(getUpgradeMessage('investor')).toBe('Upgrade to Investor Pro to unlock this feature.');
     });
 
-    it('uses correct article based on plan', () => {
+    it('uses the launch plan label in the upgrade copy', () => {
       const proMessage = getUpgradeMessage('pro');
-      expect(proMessage).toContain('a Pro');
+      expect(proMessage).toContain('Investor Starter');
 
       const investorMessage = getUpgradeMessage('investor');
-      expect(investorMessage).toContain('an Investor');
+      expect(investorMessage).toContain('Investor Pro');
     });
   });
 

--- a/frontend/__tests__/paywall.spec.tsx
+++ b/frontend/__tests__/paywall.spec.tsx
@@ -3,15 +3,21 @@ import { render, screen } from "@testing-library/react";
 import PricingPage from "@/app/pricing/page";
 
 describe("PricingPage", () => {
-  it("renders the soft-launch Free and Investor tiers", () => {
+  it("renders the Sprint 2 launch pricing tiers and founding-member copy", () => {
     render(<PricingPage />);
 
     expect(screen.getByRole("heading", { name: "Free" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Investor" })).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Pro" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Investor Starter" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Investor Pro" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Sourcer Pro" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /start free/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /start 7-day free trial/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /start starter/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /start pro/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /coming soon/i })).toBeInTheDocument();
+    expect(screen.getByText(/Founding member pricing available for early users/i)).toBeInTheDocument();
+    expect(screen.getByText("£9")).toBeInTheDocument();
     expect(screen.getByText("£19")).toBeInTheDocument();
-    expect(screen.queryByText(/off-market|pdf deal packs|portfolio analytics|alerts|crm|zapier|webhook/i)).not.toBeInTheDocument();
+    expect(screen.getByText("£39")).toBeInTheDocument();
+    expect(screen.getByText(/Unlimited saved deals \(fair usage\)/i)).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/property-deal-pack-page.spec.tsx
+++ b/frontend/__tests__/property-deal-pack-page.spec.tsx
@@ -10,6 +10,7 @@ const mockGetOptionalClerkUserId = jest.fn() as jest.MockedFunction<() => Promis
 const mockBuildPropertyDealPackModel = jest.fn() as jest.MockedFunction<
   (input: { propertyId: string; property: Record<string, unknown>; url?: string }) => { title: string }
 >;
+const mockGetServerEntitlements = jest.fn() as jest.MockedFunction<() => Promise<{ hasDealPack: boolean }>>;
 const notFoundError = Object.assign(new Error('not found'), {
   digest: 'NEXT_HTTP_ERROR_FALLBACK;404',
 });
@@ -26,6 +27,15 @@ jest.mock('@/lib/propertyDealPack', () => ({
   buildPropertyDealPackModel: mockBuildPropertyDealPackModel,
 }));
 
+jest.mock('@/lib/server/userPlan', () => ({
+  getServerEntitlements: () => mockGetServerEntitlements(),
+}));
+
+jest.mock('@/components/UpgradeButton', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+}));
+
 jest.mock('next/navigation', () => ({
   notFound: () => mockNotFound(),
 }));
@@ -39,7 +49,9 @@ describe('property/[id]/deal-pack/page', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_FEATURE_DEAL_PACK = 'true';
     mockGetOptionalClerkUserId.mockResolvedValue('user_123');
+    mockGetServerEntitlements.mockResolvedValue({ hasDealPack: true });
     mockFetchPropertyById.mockResolvedValue({ id: 'prop-123', title: 'Central Flat' });
     mockBuildPropertyDealPackModel.mockReturnValue({ title: 'Central Flat' });
   });
@@ -59,5 +71,17 @@ describe('property/[id]/deal-pack/page', () => {
         searchParams: Promise.resolve({}),
       }),
     ).rejects.toMatchObject({ digest: 'NEXT_HTTP_ERROR_FALLBACK;404' });
+  });
+
+  it('shows the gated preview when the plan does not include the Deal Pack', async () => {
+    mockGetServerEntitlements.mockResolvedValue({ hasDealPack: false });
+
+    const Page = (await import('../app/property/[id]/deal-pack/page')).default;
+    const result = await Page({
+      params: Promise.resolve({ id: 'prop-123' }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(result).toBeTruthy();
   });
 });

--- a/frontend/__tests__/property-deal-pack-page.spec.tsx
+++ b/frontend/__tests__/property-deal-pack-page.spec.tsx
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 
 import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockFetchPropertyById = jest.fn() as jest.MockedFunction<
@@ -82,6 +83,11 @@ describe('property/[id]/deal-pack/page', () => {
       searchParams: Promise.resolve({}),
     });
 
-    expect(result).toBeTruthy();
+    render(result as React.ReactElement);
+
+    expect(screen.getByText('Deal Pack preview')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /unlock investor pro/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('deal-pack-root')).not.toBeInTheDocument();
+    expect(mockBuildPropertyDealPackModel).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/api/property-pdf/[id]/route.ts
+++ b/frontend/app/api/property-pdf/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { createPropertyPdfFilename } from '@/lib/propertyDealPack';
 import { FF } from '@/lib/flags';
 import { renderDealPackPdfFromUrl } from '@/lib/server/propertyPdfRenderer';
+import { getServerEntitlements } from '@/lib/server/userPlan';
 import { fetchPropertyById, getOptionalClerkUserId } from '@/lib/server/propertyData';
 
 export const runtime = 'nodejs';
@@ -27,6 +28,14 @@ const encodeDispositionFilename = (filename: string) =>
 export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
   if (!FF.DEAL_PACK) {
     return NextResponse.json({ error: 'not_found' }, { status: 404, headers: noStoreHeaders });
+  }
+
+  const entitlements = await getServerEntitlements();
+  if (!entitlements.hasPdfExport) {
+    return NextResponse.json(
+      { error: 'upgrade_required', required_plan: 'investor_pro' },
+      { status: 403, headers: noStoreHeaders },
+    );
   }
 
   const { id } = await context.params;

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -5,28 +5,7 @@ import UpgradeButton from '@/components/UpgradeButton';
 import WaitlistForm from '@/components/WaitlistForm';
 import LegalNotice from '@/components/legal/LegalNotice';
 import { SOFT_LAUNCH_BETA_NOTICE } from '@/lib/legalCopy';
-
-const INVESTOR_PRODUCT_ID = process.env.NEXT_PUBLIC_STRIPE_PRODUCT_INVESTOR || 'prod_TGprLukyGJfRBH';
-
-const freeFeatures = [
-  'Browse property listings',
-  'Search and filter deals',
-  'View property detail pages',
-  'See core quick stats',
-  'Save deals to review later',
-  'Access basic investment signals where available',
-];
-
-const investorFeatures = [
-  'Everything in Free',
-  'Find stronger evidence signals faster with stricter Top Deal tiers',
-  'See what price makes the deal work with Offer Intelligence',
-  'Compare sold and rent evidence before bidding',
-  'Track price changes, days on market and stale listings',
-  'Save search criteria for newly surfaced strong opportunities',
-  'AI Deal Score, Investment Summary and strategy guidance',
-  'Priority access to new launch features',
-];
+import { FOUNDING_MEMBER_COPY, getCheckoutConfigForPlan, pricingPlans } from '@/lib/pricingPlans';
 
 /**
  * 7-Day Free Trial Configuration:
@@ -45,86 +24,105 @@ const investorFeatures = [
 
 export const metadata = {
   title: 'Pricing • PropNexus',
-  description: 'Choose your PropNexus plan — Free or Investor.',
+  description: 'Choose your PropNexus plan — Free, Investor Starter or Investor Pro.',
 };
 
 export default function PricingPage() {
   return (
-    <main className="mx-auto max-w-6xl px-6 pb-16 pt-20 sm:pt-24 lg:pt-28">
+    <main className="mx-auto max-w-7xl px-6 pb-16 pt-20 sm:pt-24 lg:pt-28">
       <div className="mx-auto max-w-3xl text-center">
         <p className="mb-3 text-xs font-semibold uppercase tracking-[0.22em] text-brand-600 dark:text-brand-400">
-          Soft launch pricing
+          Sprint 2 launch pricing
         </p>
         <h1 className="text-4xl font-semibold tracking-tight text-slate-950 dark:text-slate-50 sm:text-5xl">
           Choose your plan
         </h1>
         <p className="mx-auto mt-5 max-w-2xl text-base leading-7 text-slate-600 dark:text-slate-400 sm:text-lg">
-          Start free, then upgrade when you want evidence-led lead triage, offer pricing and saved-search workflows.
+          Start free, then upgrade when you want full deal labels, offer ranges and the printable Deal Pack workflow.
+        </p>
+        <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-slate-500 dark:text-slate-400">
+          {FOUNDING_MEMBER_COPY}
         </p>
       </div>
 
-      <div className="mx-auto mt-14 grid max-w-4xl grid-cols-1 items-stretch gap-8 md:grid-cols-2 lg:mt-16">
-        {/* ==== Free Tier ==== */}
-        <section className="card flex h-full flex-col p-7 transition-shadow hover:shadow-lg sm:p-8">
-          <div className="flex-1">
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Free</h2>
-            <p className="mt-3 min-h-[3.5rem] text-sm leading-6 text-slate-600 dark:text-slate-400">
-              Explore the platform and review live property opportunities.
-            </p>
-            <div className="mt-6 flex items-end gap-1">
-              <span className="text-4xl font-bold tracking-tight text-slate-950 dark:text-slate-50">£0</span>
-              <span className="pb-1 text-sm font-medium text-slate-500 dark:text-slate-400">/month</span>
-            </div>
-            <ul className="mt-7 space-y-3 text-sm text-slate-700 dark:text-slate-300">
-              {freeFeatures.map((feature) => (
-                <li key={feature} className="flex gap-3">
-                  <span className="mt-1.5 h-2 w-2 flex-none rounded-full bg-brand-500" aria-hidden="true" />
-                  <span>{feature}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="mt-8">
-            <StartFreeButton className="btn-secondary w-full justify-center">Start Free</StartFreeButton>
-          </div>
-        </section>
+      <div className="mx-auto mt-14 grid max-w-6xl grid-cols-1 items-stretch gap-6 md:grid-cols-2 xl:grid-cols-4 lg:mt-16">
+        {pricingPlans.map((plan) => {
+          const checkout = getCheckoutConfigForPlan(plan.id);
+          const highlight = plan.id === 'investor_pro';
 
-        {/* ==== Investor Tier ==== */}
-        <section className="card relative flex h-full flex-col border-2 border-brand-500 p-7 shadow-brand-md transition-shadow hover:shadow-brand-lg sm:p-8">
-          <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-brand-600 px-4 py-1 text-xs font-semibold text-white shadow-sm">
-            Launch plan
-          </div>
-          <div className="flex-1">
-            <h2 className="text-2xl font-semibold text-brand-600 dark:text-brand-400">Investor</h2>
-            <p className="mt-3 min-h-[3.5rem] text-sm leading-6 text-slate-600 dark:text-slate-400">
-              For serious investors who want stronger deal analysis and saved-deal workflows.
-            </p>
-            <div className="mt-6">
-              <div className="flex items-end gap-1">
-                <span className="text-4xl font-bold tracking-tight text-slate-950 dark:text-slate-50">£19</span>
-                <span className="pb-1 text-sm font-medium text-slate-500 dark:text-slate-400">/month</span>
+          return (
+            <section
+              key={plan.id}
+              className={`card relative flex h-full flex-col p-7 transition-shadow hover:shadow-lg sm:p-8 ${
+                highlight ? 'border-2 border-brand-500 shadow-brand-md hover:shadow-brand-lg' : ''
+              }`}
+            >
+              {plan.badge ? (
+                <div className="absolute -top-3 left-6 rounded-full bg-brand-600 px-4 py-1 text-xs font-semibold text-white shadow-sm">
+                  {plan.badge}
+                </div>
+              ) : null}
+
+              <div className="flex-1">
+                <h2 className={`text-2xl font-semibold ${highlight ? 'text-brand-600 dark:text-brand-400' : 'text-slate-900 dark:text-slate-100'}`}>
+                  {plan.name}
+                </h2>
+                <p className="mt-3 min-h-[4.5rem] text-sm leading-6 text-slate-600 dark:text-slate-400">
+                  {plan.description}
+                </p>
+                <div className="mt-6">
+                  <div className="flex items-end gap-1">
+                    <span className="text-4xl font-bold tracking-tight text-slate-950 dark:text-slate-50">
+                      {plan.monthlyLabel.replace('/month', '')}
+                    </span>
+                    <span className="pb-1 text-sm font-medium text-slate-500 dark:text-slate-400">/month</span>
+                  </div>
+                  {plan.futureMonthlyPrice ? (
+                    <div className="mt-2 text-sm font-medium text-brand-600 dark:text-brand-400">
+                      Launch price. Later £{plan.futureMonthlyPrice}/month.
+                    </div>
+                  ) : null}
+                </div>
+
+                <ul className="mt-7 space-y-3 text-sm text-slate-700 dark:text-slate-300">
+                  {plan.includes.map((feature) => (
+                    <li key={feature} className="flex gap-3">
+                      <span className="mt-1.5 h-2 w-2 flex-none rounded-full bg-brand-500" aria-hidden="true" />
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                {plan.locked?.length ? (
+                  <div className="mt-6 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300">
+                    <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                      Not included
+                    </div>
+                    <p className="mt-2">{plan.locked.join(' • ')}</p>
+                  </div>
+                ) : null}
               </div>
-              <div className="mt-2 text-sm font-medium text-brand-600 dark:text-brand-400">
-                7-day free trial
+
+              <div className="mt-8">
+                {plan.ctaMode === 'free' ? (
+                  <StartFreeButton className="btn-secondary w-full justify-center">{plan.ctaLabel}</StartFreeButton>
+                ) : plan.ctaMode === 'checkout' ? (
+                  <UpgradeButton priceId={checkout.priceId} productId={checkout.productId} className="btn-primary w-full justify-center">
+                    {plan.ctaLabel}
+                  </UpgradeButton>
+                ) : (
+                  <button type="button" disabled className="btn-secondary w-full cursor-not-allowed justify-center opacity-70">
+                    {plan.ctaLabel}
+                  </button>
+                )}
               </div>
-            </div>
-            <ul className="mt-7 space-y-3 text-sm text-slate-700 dark:text-slate-300">
-              {investorFeatures.map((feature) => (
-                <li key={feature} className="flex gap-3">
-                  <span className="mt-1.5 h-2 w-2 flex-none rounded-full bg-brand-500" aria-hidden="true" />
-                  <span>{feature}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="mt-8">
-            <UpgradeButton productId={INVESTOR_PRODUCT_ID}>Start 7-Day Free Trial</UpgradeButton>
-          </div>
-        </section>
+            </section>
+          );
+        })}
       </div>
 
       <p className="mt-10 text-center text-sm text-slate-500 dark:text-slate-400">
-        Investor starts with a 7-day free trial. No charge during the 7-day trial. Cancel anytime.
+        Free stays available. Investor Starter unlocks the first paid layer. Investor Pro unlocks the full Deal Pack workflow and PDF export.
       </p>
 
       <LegalNotice title="Subscription note" variant="compact" className="mx-auto mt-5 max-w-3xl">

--- a/frontend/app/property/[id]/deal-pack/page.tsx
+++ b/frontend/app/property/[id]/deal-pack/page.tsx
@@ -43,11 +43,13 @@ export default async function PropertyDealPackPage({ params, searchParams }: Dea
     property = await fetchPropertyById(id, userId);
     if (!property) notFound();
 
-    model = buildPropertyDealPackModel({
-      propertyId: id,
-      property,
-      url: source,
-    });
+    if (entitlements.hasDealPack) {
+      model = buildPropertyDealPackModel({
+        propertyId: id,
+        property,
+        url: source,
+      });
+    }
   } catch (error) {
     if (isNextNotFoundError(error)) {
       throw error;

--- a/frontend/app/property/[id]/deal-pack/page.tsx
+++ b/frontend/app/property/[id]/deal-pack/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
+import UpgradeButton from '@/components/UpgradeButton';
 import PropertyDealPackTemplate from '@/components/property_details/PropertyDealPackTemplate';
 import { FF } from '@/lib/flags';
 import { buildPropertyDealPackModel } from '@/lib/propertyDealPack';
+import { getCheckoutConfigForPlan } from '@/lib/pricingPlans';
+import { getServerEntitlements } from '@/lib/server/userPlan';
 import { fetchPropertyById, getOptionalClerkUserId } from '@/lib/server/propertyData';
 
 export const dynamic = 'force-dynamic';
@@ -31,10 +34,13 @@ export default async function PropertyDealPackPage({ params, searchParams }: Dea
 
   const [{ id }, { source }] = await Promise.all([params, searchParams]);
   const userId = await getOptionalClerkUserId();
+  const entitlements = await getServerEntitlements();
+  const upgrade = getCheckoutConfigForPlan('investor_pro');
   let model: ReturnType<typeof buildPropertyDealPackModel> | null = null;
+  let property: Record<string, unknown> | null = null;
 
   try {
-    const property = await fetchPropertyById(id, userId);
+    property = await fetchPropertyById(id, userId);
     if (!property) notFound();
 
     model = buildPropertyDealPackModel({
@@ -51,6 +57,32 @@ export default async function PropertyDealPackPage({ params, searchParams }: Dea
 
   if (model) {
     return <PropertyDealPackTemplate model={model} />;
+  }
+
+  if (property && !entitlements.hasDealPack) {
+    return (
+      <div className="min-h-screen bg-slate-950 px-6 py-12 text-white">
+        <div className="mx-auto max-w-4xl rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-200">Deal Pack preview</p>
+          <h1 className="mt-4 text-3xl font-semibold">{String(property.title ?? 'Property')} printable pack is part of Investor Pro</h1>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-200">
+            This preview route stays accessible so you can see what the pack includes, but the full printable layout and PDF export stay locked until Investor Pro.
+          </p>
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
+            {['Deal summary and evidence snapshot', 'Offer range, finance stress-test and walk-away framing', 'Printable PDF export for live offers'].map((item) => (
+              <div key={item} className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
+                {item}
+              </div>
+            ))}
+          </div>
+          <div className="mt-8 max-w-xs">
+            <UpgradeButton priceId={upgrade.priceId} productId={upgrade.productId} className="btn-primary w-full justify-center">
+              Unlock Investor Pro
+            </UpgradeButton>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/frontend/components/LockedFeature.tsx
+++ b/frontend/components/LockedFeature.tsx
@@ -7,7 +7,7 @@ type LockedFeatureProps = {
   /** Title shown in the header */
   title: string;
   /** Plan required to unlock (e.g., "Pro" or "Investor") */
-  requiredPlan: 'Pro' | 'Investor';
+  requiredPlan: string;
   /** Optional custom message */
   message?: string;
   /** Children shown blurred/minimized when locked */
@@ -23,7 +23,7 @@ export default function LockedFeature({
   children,
   showPreview = true,
 }: LockedFeatureProps) {
-  const defaultMessage = `Upgrade to ${requiredPlan} to unlock this feature`;
+  const defaultMessage = `Unlock ${title} with ${requiredPlan}.`;
 
   return (
     <div className="relative">

--- a/frontend/components/UpgradeButton.tsx
+++ b/frontend/components/UpgradeButton.tsx
@@ -45,6 +45,10 @@ export default function UpgradeButton({ priceId, productId, children = 'Upgrade'
 
     setLoading(true);
     try {
+      if (!priceId && !productId) {
+        throw new Error('Checkout is not configured yet.');
+      }
+
       const r = await fetch('/api/stripe/checkout', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },

--- a/frontend/components/__tests__/GatedPanelEntitlement.spec.tsx
+++ b/frontend/components/__tests__/GatedPanelEntitlement.spec.tsx
@@ -75,7 +75,9 @@ describe('GatedPanel entitlement', () => {
 
     expect(screen.getByTestId('locked-feature')).toBeInTheDocument();
     expect(
-      screen.getByText('AI Deal Score is available on Pro and Investor plans. Your current plan is Free.'),
+      screen.getByText(
+        'Upgrade to unlock AI Deal Score. This section is available on Investor Starter or Investor Pro. Your current plan is Free.',
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByTestId('deal-score-content')).not.toBeInTheDocument();
     expect(screen.queryByTestId('locked-preview')).not.toBeInTheDocument();

--- a/frontend/components/property_details/GatedPanel.tsx
+++ b/frontend/components/property_details/GatedPanel.tsx
@@ -6,11 +6,12 @@ import { useUserPlan } from '@/lib/useUserPlan';
 import { getPlanLabel, hasAccess } from '@/lib/planPermissions';
 import LockedFeature from '@/components/LockedFeature';
 import { isAuthEnabled } from '@/lib/auth';
+import type { UserPlan } from '@/lib/useUserPlan';
 
 interface GatedPanelProps {
   children: ReactNode;
   title: string;
-  requiredPlan: 'pro' | 'investor';
+  requiredPlan: Exclude<UserPlan, 'free'>;
   featureEnabled: boolean;
   showPreviewWhenLocked?: boolean;
 }
@@ -79,13 +80,17 @@ function GatedPanelAuthed({
   const userHasAccess = bypassGating || hasAccess(plan, requiredPlan);
 
   if (!userHasAccess) {
-    const requiredLabel = requiredPlan === 'pro' ? 'Pro' : 'Investor';
+    const requiredLabel = getPlanLabel(requiredPlan);
     const currentLabel = getPlanLabel(plan);
+    const availabilityCopy =
+      requiredPlan === 'pro'
+        ? 'Investor Starter or Investor Pro'
+        : 'Investor Pro';
     return (
       <LockedFeature
         title={title}
         requiredPlan={requiredLabel}
-        message={`${title} is available on ${requiredLabel} and Investor plans. Your current plan is ${currentLabel}.`}
+        message={`Upgrade to unlock ${title}. This section is available on ${availabilityCopy}. Your current plan is ${currentLabel}.`}
         showPreview={showPreviewWhenLocked}
       >
         {children}

--- a/frontend/components/property_details/OfferIntelligence.spec.tsx
+++ b/frontend/components/property_details/OfferIntelligence.spec.tsx
@@ -1,13 +1,23 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('@/components/property_details/GatedPanel', () =>
-  function MockGatedPanel({ children }: { children: React.ReactNode }) {
-    return <>{children}</>;
+const mockUseUserPlan = jest.fn();
+
+jest.mock('@/lib/useUserPlan', () => ({
+  useUserPlan: () => mockUseUserPlan(),
+}));
+
+jest.mock('@/components/UpgradeButton', () =>
+  function MockUpgradeButton({ children }: { children: React.ReactNode }) {
+    return <button type="button">{children}</button>;
   }
 );
 
 describe('OfferIntelligence', () => {
+  beforeEach(() => {
+    mockUseUserPlan.mockReturnValue({ plan: 'investor', loading: false, error: null, refetch: jest.fn() });
+  });
+
   it('renders target price calculations from evidenced rent', async () => {
     const OfferIntelligence = require('./OfferIntelligence').default;
     render(
@@ -31,6 +41,57 @@ describe('OfferIntelligence', () => {
     expect(screen.getAllByText('£200,000').length).toBeGreaterThan(0);
     expect(screen.getByText('£171,429')).toBeInTheDocument();
     expect(screen.getByText('Income case improves materially below £171,429.')).toBeInTheDocument();
+  });
+
+  it('shows a Starter upgrade preview for free users', async () => {
+    mockUseUserPlan.mockReturnValue({ plan: 'free', loading: false, error: null, refetch: jest.fn() });
+
+    const OfferIntelligence = require('./OfferIntelligence').default;
+    render(
+      <OfferIntelligence
+        intel={{
+          asking_price: 200000,
+          current_monthly_rent: 1000,
+          gross_yield_percent: 6,
+          rent_evidence: { is_real_rent_evidence: true, source: 'provided' },
+          offer_intelligence: {
+            rent_required_at_asking: { '6': 1000, '7': 1166.67, '8': 1333.33 },
+            target_purchase_price_from_rent: { '6': 200000, '7': 171429, '8': 150000 },
+          },
+          sold_comp_benchmark: { benchmark_confidence: 'limited' },
+          conclusion: 'Income case improves materially below £171,429.',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Offer range preview')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /unlock investor starter/i })).toBeInTheDocument();
+  });
+
+  it('shows an indicative range for Starter users and reserves full underwriting for Pro', async () => {
+    mockUseUserPlan.mockReturnValue({ plan: 'pro', loading: false, error: null, refetch: jest.fn() });
+
+    const OfferIntelligence = require('./OfferIntelligence').default;
+    render(
+      <OfferIntelligence
+        intel={{
+          asking_price: 200000,
+          current_monthly_rent: 1000,
+          gross_yield_percent: 6,
+          rent_evidence: { is_real_rent_evidence: true, source: 'provided' },
+          offer_intelligence: {
+            rent_required_at_asking: { '6': 1000, '7': 1166.67, '8': 1333.33 },
+            target_purchase_price_from_rent: { '6': 200000, '7': 171429, '8': 150000 },
+          },
+          sold_comp_benchmark: { benchmark_confidence: 'limited' },
+          conclusion: 'Income case improves materially below £171,429.',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Starter offer range')).toBeInTheDocument();
+    expect(screen.getByText(/£150,000 to £200,000/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /unlock investor pro/i })).toBeInTheDocument();
   });
 
   it('labels missing rent evidence without overclaiming comps', async () => {

--- a/frontend/components/property_details/OfferIntelligence.tsx
+++ b/frontend/components/property_details/OfferIntelligence.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import GatedPanel from '@/components/property_details/GatedPanel';
+import UpgradeButton from '@/components/UpgradeButton';
+import { getCheckoutConfigForPlan } from '@/lib/pricingPlans';
+import { getEntitlements } from '@/lib/entitlements';
+import { useUserPlan } from '@/lib/useUserPlan';
 import type { InvestorIntel } from '@/types/investorIntel';
 
 export function fmtGBP(n: unknown): string {
@@ -15,12 +18,88 @@ function fmtPct(n: unknown): string {
 }
 
 export default function OfferIntelligence({ intel, loading = false }: { intel: InvestorIntel | null; loading?: boolean }) {
+  const { plan } = useUserPlan();
+  const entitlements = getEntitlements(plan);
   const hasVerifiedRentEvidence = Boolean(intel?.rent_evidence?.is_real_rent_evidence);
   const rawConclusion = typeof intel?.conclusion === 'string' ? intel.conclusion.trim() : '';
   const conclusionText =
     !hasVerifiedRentEvidence && /insufficient rent evidence/i.test(rawConclusion)
       ? 'Add verified rent evidence to unlock a reliable target offer and walk-away price.'
       : rawConclusion;
+  const targetPriceMap = intel?.offer_intelligence?.target_purchase_price_from_rent ?? null;
+  const availableTargetPrices = ['6', '7', '8']
+    .map((key) => Number(targetPriceMap?.[key as keyof typeof targetPriceMap]))
+    .filter((value) => Number.isFinite(value) && value > 0);
+  const indicativeLow = availableTargetPrices.length ? Math.min(...availableTargetPrices) : null;
+  const indicativeHigh = availableTargetPrices.length ? Math.max(...availableTargetPrices) : null;
+  const starterCheckout = getCheckoutConfigForPlan('investor_starter');
+  const proCheckout = getCheckoutConfigForPlan('investor_pro');
+
+  const offerRangeSection = entitlements.hasFullOfferRange ? (
+    <div className="grid gap-3 lg:grid-cols-2">
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/40">
+        <h4 className="font-black text-slate-950 dark:text-white">Rent required at asking price</h4>
+        <div className="mt-3 grid grid-cols-3 gap-2 text-sm">
+          {['6', '7', '8'].map((t) => (
+            <div key={t} className="rounded-xl bg-white p-3 dark:bg-slate-950/50">
+              <div className="text-xs text-slate-500">{t}% yield</div>
+              <div className="font-bold">{fmtGBP(intel?.offer_intelligence?.rent_required_at_asking?.[t])}/mo</div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/40">
+        <h4 className="font-black text-slate-950 dark:text-white">Target price from evidenced rent</h4>
+        <div className="mt-3 grid grid-cols-3 gap-2 text-sm">
+          {['6', '7', '8'].map((t) => (
+            <div key={t} className="rounded-xl bg-white p-3 dark:bg-slate-950/50">
+              <div className="text-xs text-slate-500">{t}% yield</div>
+              <div className="font-bold">{fmtGBP(intel?.offer_intelligence?.target_purchase_price_from_rent?.[t])}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  ) : entitlements.hasBasicOfferRange ? (
+    <div className="rounded-2xl border border-brand-200 bg-brand-50/80 p-4 dark:border-brand-900/60 dark:bg-brand-950/20">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700 dark:text-brand-200">Starter offer range</div>
+          <h4 className="mt-1 text-lg font-black text-slate-950 dark:text-white">Indicative range from evidenced rent</h4>
+          <p className="mt-2 text-sm text-slate-700 dark:text-slate-300">
+            {hasVerifiedRentEvidence && indicativeLow !== null && indicativeHigh !== null
+              ? `${fmtGBP(indicativeLow)} to ${fmtGBP(indicativeHigh)} gives you a first-pass buy box before you underwrite finance and walk-away discipline.`
+              : 'Rent evidence is still too weak for a reliable indicative range. Add verified rent or comparable evidence before relying on target pricing.'}
+          </p>
+        </div>
+        <div className="min-w-[14rem]">
+          <UpgradeButton priceId={proCheckout.priceId} productId={proCheckout.productId} className="btn-primary w-full justify-center">
+            Unlock Investor Pro
+          </UpgradeButton>
+        </div>
+      </div>
+      <p className="mt-3 text-xs text-slate-600 dark:text-slate-300">
+        Investor Pro adds target offer, max offer, walk-away pricing and PDF-ready Deal Pack export.
+      </p>
+    </div>
+  ) : (
+    <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/80 p-4 dark:border-slate-700 dark:bg-slate-900/40">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">Offer range preview</div>
+          <h4 className="mt-1 text-lg font-black text-slate-950 dark:text-white">Upgrade to see what price makes the deal work</h4>
+          <p className="mt-2 text-sm text-slate-700 dark:text-slate-300">
+            Free users can review the evidence snapshot and yield context. Investor Starter unlocks an indicative offer range when the rent evidence is strong enough.
+          </p>
+        </div>
+        <div className="min-w-[14rem]">
+          <UpgradeButton priceId={starterCheckout.priceId} productId={starterCheckout.productId} className="btn-primary w-full justify-center">
+            Unlock Investor Starter
+          </UpgradeButton>
+        </div>
+      </div>
+    </div>
+  );
 
   const body = loading ? (
     <div className="animate-pulse space-y-3">
@@ -47,30 +126,7 @@ export default function OfferIntelligence({ intel, loading = false }: { intel: I
         </div>
       </div>
 
-      <div className="grid gap-3 lg:grid-cols-2">
-        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/40">
-          <h4 className="font-black text-slate-950 dark:text-white">Rent required at asking price</h4>
-          <div className="mt-3 grid grid-cols-3 gap-2 text-sm">
-            {['6', '7', '8'].map((t) => (
-              <div key={t} className="rounded-xl bg-white p-3 dark:bg-slate-950/50">
-                <div className="text-xs text-slate-500">{t}% yield</div>
-                <div className="font-bold">{fmtGBP(intel.offer_intelligence?.rent_required_at_asking?.[t])}/mo</div>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/40">
-          <h4 className="font-black text-slate-950 dark:text-white">Target price from evidenced rent</h4>
-          <div className="mt-3 grid grid-cols-3 gap-2 text-sm">
-            {['6', '7', '8'].map((t) => (
-              <div key={t} className="rounded-xl bg-white p-3 dark:bg-slate-950/50">
-                <div className="text-xs text-slate-500">{t}% yield</div>
-                <div className="font-bold">{fmtGBP(intel.offer_intelligence?.target_purchase_price_from_rent?.[t])}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
+      {offerRangeSection}
 
       <div className="rounded-2xl border border-brand-200 bg-brand-50 p-4 text-sm dark:border-brand-900/60 dark:bg-brand-950/20">
         <div className="font-black text-brand-900 dark:text-brand-100">Conclusion</div>
@@ -87,9 +143,5 @@ export default function OfferIntelligence({ intel, loading = false }: { intel: I
     </div>
   );
 
-  return (
-    <GatedPanel title="Offer Intelligence" requiredPlan="investor" featureEnabled={true} showPreviewWhenLocked>
-      {body}
-    </GatedPanel>
-  );
+  return body;
 }

--- a/frontend/components/property_details/QuickStatsActions.export.spec.tsx
+++ b/frontend/components/property_details/QuickStatsActions.export.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import QuickStatsActions from './QuickStatsActions';
 
 const mockFetchWithRetry = jest.fn();
+const mockUseUserPlan = jest.fn();
 const mockFlagState = {
   DEAL_PACK: false,
   CRM_EXPORT: false,
@@ -18,6 +19,10 @@ jest.mock('@/lib/flags', () => ({
   },
 }));
 
+jest.mock('@/lib/useUserPlan', () => ({
+  useUserPlan: () => mockUseUserPlan(),
+}));
+
 jest.mock('sonner', () => ({
   toast: {
     success: jest.fn(),
@@ -28,6 +33,7 @@ jest.mock('sonner', () => ({
 describe('QuickStatsActions launch controls', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseUserPlan.mockReturnValue({ plan: 'free', loading: false, error: null, refetch: jest.fn() });
     mockFlagState.DEAL_PACK = false;
     mockFlagState.CRM_EXPORT = false;
     mockFetchWithRetry.mockResolvedValue({
@@ -74,6 +80,7 @@ describe('QuickStatsActions launch controls', () => {
   it('can re-enable deal pack and CRM export actions independently', () => {
     mockFlagState.DEAL_PACK = true;
     mockFlagState.CRM_EXPORT = true;
+    mockUseUserPlan.mockReturnValue({ plan: 'investor', loading: false, error: null, refetch: jest.fn() });
 
     render(
       <QuickStatsActions
@@ -84,6 +91,20 @@ describe('QuickStatsActions launch controls', () => {
 
     expect(screen.getAllByRole('button', { name: /export property details as pdf/i }).length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: /copy property data as json/i })).toBeInTheDocument();
+  });
+
+  it('keeps PDF export locked for Investor Starter even when the feature flag is enabled', () => {
+    mockFlagState.DEAL_PACK = true;
+    mockUseUserPlan.mockReturnValue({ plan: 'pro', loading: false, error: null, refetch: jest.fn() });
+
+    render(
+      <QuickStatsActions
+        propertyId="prop-457"
+        property={{ title: 'Starter plan flat', location: 'Manchester' }}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /export property details as pdf/i })).not.toBeInTheDocument();
   });
 
   it('does not mark saved when the API returns only unrelated saved deals', async () => {

--- a/frontend/components/property_details/QuickStatsActions.tsx
+++ b/frontend/components/property_details/QuickStatsActions.tsx
@@ -4,9 +4,11 @@ import { useEffect, useMemo, useState } from 'react';
 import { FiHeart, FiShare2, FiDownload, FiCopy, FiCheck, FiExternalLink } from 'react-icons/fi';
 import { toast } from 'sonner';
 import { fetchWithRetry } from '@/lib/api';
+import { getEntitlements } from '@/lib/entitlements';
 import { exportPropertyPdf } from '@/lib/propertyPdfExport';
 import { createPropertyPdfFilename } from '@/lib/propertyDealPack';
 import { FF } from '@/lib/flags';
+import { useUserPlan } from '@/lib/useUserPlan';
 import {
   formatPercent,
   formatRoiDisplay,
@@ -65,12 +67,14 @@ export default function QuickStatsActions({
   discountPercent,
   aiScore,
 }: QuickStatsActionsProps) {
+  const { plan } = useUserPlan();
+  const entitlements = getEntitlements(plan);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [copied, setCopied] = useState(false);
   const [dealEnquiryCopied, setDealEnquiryCopied] = useState(false);
   const [exporting, setExporting] = useState(false);
-  const showDealPackExport = FF.DEAL_PACK;
+  const showDealPackExport = FF.DEAL_PACK && entitlements.hasPdfExport;
   const showCrmExports = FF.CRM_EXPORT;
 
   const merged = useMemo(() => {

--- a/frontend/lib/entitlements.ts
+++ b/frontend/lib/entitlements.ts
@@ -1,0 +1,84 @@
+import type { UserPlan } from '@/lib/useUserPlan';
+import { getPricingPlan, type PricingPlanId } from '@/lib/pricingPlans';
+
+export type BackendUserPlan = UserPlan;
+
+export type DealDeskEntitlements = {
+  backendPlan: BackendUserPlan;
+  launchPlanId: PricingPlanId;
+  launchPlanLabel: string;
+  hasFullDealLabel: boolean;
+  hasBasicOfferRange: boolean;
+  hasFullOfferRange: boolean;
+  hasDealPack: boolean;
+  hasFinanceStressTest: boolean;
+  hasPdfExport: boolean;
+  hasSourcerBranding: boolean;
+};
+
+const VALID_BACKEND_PLANS: BackendUserPlan[] = ['free', 'pro', 'investor'];
+
+export function normalizeBackendPlan(raw: unknown): BackendUserPlan {
+  if (typeof raw !== 'string') return 'free';
+  const normalized = raw.trim().toLowerCase();
+  if (VALID_BACKEND_PLANS.includes(normalized as BackendUserPlan)) {
+    return normalized as BackendUserPlan;
+  }
+  if (normalized === 'investor_starter' || normalized === 'starter') return 'pro';
+  if (normalized === 'investor_pro' || normalized === 'pro_plus') return 'investor';
+  return 'free';
+}
+
+export function getPlanFromUser(payload: { plan?: unknown } | null | undefined): BackendUserPlan {
+  return normalizeBackendPlan(payload?.plan);
+}
+
+export function getPlanFromStatus(payload: unknown): BackendUserPlan {
+  if (payload && typeof payload === 'object') {
+    const direct = normalizeBackendPlan((payload as { plan?: unknown }).plan);
+    if (direct !== 'free' || (payload as { plan?: unknown }).plan === 'free') return direct;
+
+    const nested = (payload as { subscription?: { plan?: unknown } | null }).subscription;
+    if (nested) {
+      return normalizeBackendPlan(nested.plan);
+    }
+  }
+  return 'free';
+}
+
+export function getLaunchPlanId(plan: BackendUserPlan): PricingPlanId {
+  switch (normalizeBackendPlan(plan)) {
+    case 'pro':
+      return 'investor_starter';
+    case 'investor':
+      return 'investor_pro';
+    default:
+      return 'free';
+  }
+}
+
+export function getEntitlements(plan: BackendUserPlan): DealDeskEntitlements {
+  const backendPlan = normalizeBackendPlan(plan);
+  const launchPlanId = getLaunchPlanId(backendPlan);
+  const launchPlan = getPricingPlan(launchPlanId);
+  const level = backendPlan === 'investor' ? 2 : backendPlan === 'pro' ? 1 : 0;
+
+  return {
+    backendPlan,
+    launchPlanId,
+    launchPlanLabel: launchPlan.name,
+    hasFullDealLabel: level >= 1,
+    hasBasicOfferRange: level >= 1,
+    hasFullOfferRange: level >= 2,
+    hasDealPack: level >= 2,
+    hasFinanceStressTest: level >= 2,
+    hasPdfExport: level >= 2,
+    hasSourcerBranding: false,
+  };
+}
+
+export function isPlanConfiguredForCheckout(planId: PricingPlanId): boolean {
+  if (planId === 'free' || planId === 'sourcer_pro') return false;
+  const plan = getPricingPlan(planId);
+  return Boolean(plan.checkout.priceEnv || plan.checkout.productEnv || plan.checkout.fallbackProductId);
+}

--- a/frontend/lib/planPermissions.ts
+++ b/frontend/lib/planPermissions.ts
@@ -1,5 +1,7 @@
 // frontend/lib/planPermissions.ts
 import { UserPlan } from './useUserPlan';
+import { getLaunchPlanId } from './entitlements';
+import { getPricingPlan } from './pricingPlans';
 
 // Plan hierarchy: free < pro < investor
 const PLAN_LEVELS: Record<UserPlan, number> = {
@@ -34,12 +36,8 @@ export function hasAccess(userPlan: UserPlan, requiredPlan: UserPlan): boolean {
  * @returns Capitalized plan name
  */
 export function getPlanLabel(plan: UserPlan): string {
-  const labels: Record<UserPlan, string> = {
-    free: 'Free',
-    pro: 'Pro',
-    investor: 'Investor',
-  };
-  return labels[plan] || 'Free';
+  const launchPlanId = getLaunchPlanId(plan);
+  return getPricingPlan(launchPlanId).name;
 }
 
 /**
@@ -49,7 +47,8 @@ export function getPlanLabel(plan: UserPlan): string {
  * @returns 'an' for 'investor', 'a' for others
  */
 export function getPlanArticle(plan: UserPlan): string {
-  return plan === 'investor' ? 'an' : 'a';
+  const label = getPlanLabel(plan);
+  return /^[aeiou]/i.test(label) ? 'an' : 'a';
 }
 
 /**
@@ -59,7 +58,6 @@ export function getPlanArticle(plan: UserPlan): string {
  * @returns A user-friendly message
  */
 export function getUpgradeMessage(requiredPlan: UserPlan): string {
-  const article = getPlanArticle(requiredPlan);
   const label = getPlanLabel(requiredPlan);
-  return `This feature requires ${article} ${label} plan.`;
+  return `Upgrade to ${label} to unlock this feature.`;
 }

--- a/frontend/lib/pricingPlans.ts
+++ b/frontend/lib/pricingPlans.ts
@@ -1,0 +1,140 @@
+import type { UserPlan } from '@/lib/useUserPlan';
+
+export type PricingPlanId = 'free' | 'investor_starter' | 'investor_pro' | 'sourcer_pro';
+
+export type PricingPlan = {
+  id: PricingPlanId;
+  backendPlan: UserPlan | null;
+  name: string;
+  badge?: string;
+  monthlyLabel: string;
+  launchMonthlyPrice: number;
+  futureMonthlyPrice: number | null;
+  description: string;
+  ctaLabel: string;
+  ctaMode: 'free' | 'checkout' | 'coming_soon';
+  checkout: {
+    priceEnv?: string;
+    productEnv?: string;
+    fallbackProductId?: string;
+  };
+  includes: string[];
+  locked?: string[];
+  comingSoon?: boolean;
+};
+
+const STARTER_PRICE_ID = (process.env.NEXT_PUBLIC_STRIPE_PRICE_PRO || '').trim();
+const STARTER_PRODUCT_ID = (process.env.NEXT_PUBLIC_STRIPE_PRODUCT_PRO || '').trim();
+const PRO_PRICE_ID = (process.env.NEXT_PUBLIC_STRIPE_PRICE_INVESTOR || '').trim();
+const PRO_PRODUCT_ID = (process.env.NEXT_PUBLIC_STRIPE_PRODUCT_INVESTOR || 'prod_TGprLukyGJfRBH').trim();
+const SOURCER_PRICE_ID = (process.env.NEXT_PUBLIC_STRIPE_PRICE_SOURCER_PRO || '').trim();
+const SOURCER_PRODUCT_ID = (process.env.NEXT_PUBLIC_STRIPE_PRODUCT_SOURCER_PRO || '').trim();
+
+export const FOUNDING_MEMBER_COPY =
+  'Founding member pricing available for early users. Prices may increase as PropNexus adds more data, Deal Pack features and integrations.';
+
+export const pricingPlans: PricingPlan[] = [
+  {
+    id: 'free',
+    backendPlan: 'free',
+    name: 'Free',
+    monthlyLabel: '£0/month',
+    launchMonthlyPrice: 0,
+    futureMonthlyPrice: null,
+    description: 'Explore the Deal Desk with lightweight previews before you upgrade.',
+    ctaLabel: 'Start free',
+    ctaMode: 'free',
+    checkout: {},
+    includes: [
+      '3 basic analyses/month',
+      'Basic Deal Label preview',
+      'Basic yield estimate',
+      'Limited saved deals',
+    ],
+    locked: ['Full offer range', 'Full Deal Pack', 'PDF export', 'Finance stress-test'],
+  },
+  {
+    id: 'investor_starter',
+    backendPlan: 'pro',
+    name: 'Investor Starter',
+    badge: 'Launch price',
+    monthlyLabel: '£9/month',
+    launchMonthlyPrice: 9,
+    futureMonthlyPrice: 19,
+    description: 'For investors who want a sharper deal read before they offer.',
+    ctaLabel: 'Start Starter',
+    ctaMode: 'checkout',
+    checkout: {
+      priceEnv: STARTER_PRICE_ID,
+      productEnv: STARTER_PRODUCT_ID,
+    },
+    includes: [
+      'Full Deal Label',
+      'Basic offer range where evidence supports it',
+      'Saved deals workspace',
+      'Investor checklist',
+    ],
+    locked: ['Full Deal Pack', 'PDF export', 'Finance stress-test'],
+  },
+  {
+    id: 'investor_pro',
+    backendPlan: 'investor',
+    name: 'Investor Pro',
+    badge: 'Best for live offers',
+    monthlyLabel: '£19/month',
+    launchMonthlyPrice: 19,
+    futureMonthlyPrice: 39,
+    description: 'Unlock the full Deal Desk workflow when you are ready to underwrite and move.',
+    ctaLabel: 'Start Pro',
+    ctaMode: 'checkout',
+    checkout: {
+      priceEnv: PRO_PRICE_ID,
+      productEnv: PRO_PRODUCT_ID,
+      fallbackProductId: 'prod_TGprLukyGJfRBH',
+    },
+    includes: [
+      'Full Deal Pack',
+      'Target offer, max offer and walk-away price',
+      'Finance stress-test',
+      'PDF export',
+      'Unlimited saved deals (fair usage)',
+    ],
+  },
+  {
+    id: 'sourcer_pro',
+    backendPlan: null,
+    name: 'Sourcer Pro',
+    badge: 'Coming next',
+    monthlyLabel: '£39/month',
+    launchMonthlyPrice: 39,
+    futureMonthlyPrice: 79,
+    description: 'Reserved for Sprint 3 branded client-ready reporting and sourcer workflows.',
+    ctaLabel: 'Coming soon',
+    ctaMode: 'coming_soon',
+    checkout: {
+      priceEnv: SOURCER_PRICE_ID,
+      productEnv: SOURCER_PRODUCT_ID,
+    },
+    includes: ['Coming next: branded sourcer reporting'],
+    locked: ['Sprint 3 branded reports', 'Client-ready sourcer exports'],
+    comingSoon: true,
+  },
+];
+
+export function getPricingPlan(planId: PricingPlanId): PricingPlan {
+  return pricingPlans.find((plan) => plan.id === planId) ?? pricingPlans[0];
+}
+
+export function getCheckoutConfigForPlan(planId: PricingPlanId): {
+  priceId?: string;
+  productId?: string;
+} {
+  const plan = getPricingPlan(planId);
+  const priceId = plan.checkout.priceEnv?.trim();
+  const productId = plan.checkout.productEnv?.trim() || plan.checkout.fallbackProductId?.trim();
+
+  return {
+    ...(priceId ? { priceId } : {}),
+    ...(productId ? { productId } : {}),
+  };
+}

--- a/frontend/lib/server/userPlan.ts
+++ b/frontend/lib/server/userPlan.ts
@@ -1,0 +1,63 @@
+import { auth, clerkClient } from '@clerk/nextjs/server';
+
+import { getEntitlements, getPlanFromUser, type BackendUserPlan, type DealDeskEntitlements } from '@/lib/entitlements';
+import { backendFetch } from '@/lib/server/propertyData';
+
+function isClerkServerEnabled(): boolean {
+  const pk = (process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '').trim();
+  const sk = (process.env.CLERK_SECRET_KEY ?? '').trim();
+  const disable = ['1', 'true', 'yes', 'on'].includes(
+    (process.env.NEXT_PUBLIC_DISABLE_AUTH ?? '').trim().toLowerCase(),
+  );
+  return !disable && pk.startsWith('pk_') && Boolean(sk);
+}
+
+function getEmailFromSessionClaims(claims: unknown): string | null {
+  if (!claims || typeof claims !== 'object') return null;
+
+  for (const key of ['email', 'email_address', 'primary_email_address'] as const) {
+    const value = (claims as Record<string, unknown>)[key];
+    if (typeof value === 'string' && value.includes('@')) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+export async function getOptionalSignedInEmail(): Promise<string | null> {
+  if (!isClerkServerEnabled()) return null;
+
+  const session: any = await auth();
+  const claimEmail = getEmailFromSessionClaims(session?.sessionClaims);
+  if (claimEmail) return claimEmail;
+
+  const userId = (session?.userId as string | null) ?? null;
+  if (!userId) return null;
+
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  return user.primaryEmailAddress?.emailAddress ?? user.emailAddresses?.[0]?.emailAddress ?? null;
+}
+
+export async function getServerUserPlan(): Promise<BackendUserPlan> {
+  try {
+    const email = await getOptionalSignedInEmail();
+    if (!email) return 'free';
+
+    const res = await backendFetch(`/users/plan?email=${encodeURIComponent(email)}`, {
+      method: 'GET',
+      headers: { 'content-type': 'application/json' },
+    });
+
+    if (!res.ok) return 'free';
+    const payload = (await res.json().catch(() => null)) as { plan?: unknown } | null;
+    return getPlanFromUser(payload);
+  } catch {
+    return 'free';
+  }
+}
+
+export async function getServerEntitlements(): Promise<DealDeskEntitlements> {
+  return getEntitlements(await getServerUserPlan());
+}


### PR DESCRIPTION
## Summary

Launch pricing for Sprint 2:
- Free: £0/month
- Investor Starter: £9/month launch, later £19/month
- Investor Pro: £19/month launch, later £39/month
- Sourcer Pro: £39/month launch, later £79/month, coming soon only

Free gets:
- Pricing page access and launch tier copy
- Offer Intelligence evidence and yield preview
- Deal Pack preview page by direct route
- No full offer range, no full Deal Pack, no PDF export

Investor Starter gets:
- Launch-mapped paid tier on top of existing backend `pro`
- Indicative offer range when evidence is strong enough
- Saved deals workspace and paid-tier upgrade path
- No PDF export and no full printable Deal Pack

Investor Pro gets:
- Full offer range outputs
- Full Deal Pack route output
- PDF export access
- Full printable underwriting workflow

Sourcer Pro does not yet implement:
- Branded sourcer reports
- Client-ready sourcer exports
- Sourcer branding workflows
- Live checkout flow in this sprint

Stripe env vars needed:
- NEXT_PUBLIC_STRIPE_PRICE_PRO
- NEXT_PUBLIC_STRIPE_PRODUCT_PRO
- NEXT_PUBLIC_STRIPE_PRICE_INVESTOR
- NEXT_PUBLIC_STRIPE_PRODUCT_INVESTOR
- NEXT_PUBLIC_STRIPE_PRICE_SOURCER_PRO optional
- NEXT_PUBLIC_STRIPE_PRODUCT_SOURCER_PRO optional
- Existing backend Stripe env vars remain unchanged

Validation:
- `python -m pytest backend/tests/ -q` ✅
- `npm --prefix frontend test -- --ci` ✅
- `npm --prefix frontend run lint` ✅
- `NEXT_TELEMETRY_DISABLED=1 NEXT_PRIVATE_BUILD_WORKER=1 npm --prefix frontend run build` ✅

Scope confirmations:
- Sprint 2B credits were not started
- Sprint 3 Sourcer Pro branded reports were not started
