### PR TITLE
fix(stripe): repair checkout success redirect

### DIFF
--- a/backend/tests/test_stripe_trial.py
+++ b/backend/tests/test_stripe_trial.py
@@ -69,6 +69,11 @@ def test_checkout_session_includes_trial(mock_sb, mock_stripe, client):
     assert "subscription_data" in call_kwargs
     assert call_kwargs["subscription_data"]["trial_period_days"] == 7
     assert call_kwargs["mode"] == "subscription"
+    assert (
+        call_kwargs["success_url"]
+        == "http://localhost:3000/success?session_id={CHECKOUT_SESSION_ID}"
+    )
+    assert call_kwargs["cancel_url"] == "http://localhost:3000/pricing"
 
 
 @patch("backend.routes.stripe_routes.stripe")

--- a/frontend/__tests__/account-page.spec.tsx
+++ b/frontend/__tests__/account-page.spec.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import AccountPage from '@/app/account/page';
+
+let mockPlan: 'free' | 'pro' | 'investor' = 'free';
+const mockRefetchPlan = jest.fn();
+
+jest.mock('@/lib/auth', () => ({
+  isAuthEnabled: true,
+}));
+
+jest.mock('@clerk/nextjs', () => ({
+  useUser: () => ({
+    isLoaded: true,
+    isSignedIn: true,
+    user: {
+      primaryEmailAddress: {
+        emailAddress: 'user@example.com',
+      },
+    },
+  }),
+}));
+
+jest.mock('@/lib/useUserPlan', () => ({
+  useUserPlan: () => ({
+    plan: mockPlan,
+    loading: false,
+    error: null,
+    refetch: mockRefetchPlan,
+  }),
+}));
+
+describe('/account page', () => {
+  it.each([
+    ['free', 'Free'],
+    ['pro', 'Investor Starter'],
+    ['investor', 'Investor Pro'],
+  ] as const)('displays the %s backend plan as %s', (plan, label) => {
+    mockPlan = plan;
+
+    render(<AccountPage />);
+
+    expect(screen.getByRole('heading', { name: 'Manage Subscription' })).toBeInTheDocument();
+    expect(screen.getAllByRole('status', { name: `Current plan: ${label}` }).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/__tests__/api-stripe-create-checkout-session-route.spec.ts
+++ b/frontend/__tests__/api-stripe-create-checkout-session-route.spec.ts
@@ -1,0 +1,68 @@
+/** @jest-environment node */
+
+const mockAuth = jest.fn();
+const mockGetUser = jest.fn();
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+  clerkClient: async () => ({
+    users: {
+      getUser: mockGetUser,
+    },
+  }),
+}));
+
+describe('/api/stripe/create-checkout-session', () => {
+  const oldEnv = process.env;
+  const oldFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = {
+      ...oldEnv,
+      NEXT_PUBLIC_BACKEND_URL: 'https://backend.example',
+      PROPNEXUS_INTERNAL_API_TOKEN: 'test-internal-token',
+      NEXT_PUBLIC_DISABLE_AUTH: 'true',
+    };
+    mockAuth.mockReset();
+    mockGetUser.mockReset();
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+    global.fetch = oldFetch;
+  });
+
+  it('proxies checkout session creation to the backend without exposing secrets', async () => {
+    global.fetch = jest.fn(async () => {
+      return new Response(JSON.stringify({ url: 'https://checkout.stripe.com/c/session_123' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    const { POST } = await import('@/app/api/stripe/create-checkout-session/route');
+    const res = await POST(
+      new Request('http://localhost/api/stripe/create-checkout-session', {
+        method: 'POST',
+        body: JSON.stringify({ price_id: 'price_test_123', email: 'user@example.com' }),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ url: 'https://checkout.stripe.com/c/session_123' });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://backend.example/stripe/create-checkout-session',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'X-PropNexus-Internal-Token': 'test-internal-token',
+          'x-propnexus-user-email': 'user@example.com',
+        }),
+      }),
+    );
+    expect(JSON.stringify(body)).not.toContain('test-internal-token');
+  });
+});

--- a/frontend/__tests__/success-page.spec.tsx
+++ b/frontend/__tests__/success-page.spec.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import SuccessPage from '@/app/success/page';
+
+describe('/success page', () => {
+  it('renders a safe checkout-complete state with a session id', async () => {
+    render(await SuccessPage({ searchParams: Promise.resolve({ session_id: 'cs_test_123' }) }));
+
+    expect(screen.getByRole('heading', { name: /checkout complete/i })).toBeInTheDocument();
+    expect(screen.getByText(/your subscription is being activated/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /go to account/i })).toHaveAttribute('href', '/account');
+    expect(screen.getByRole('link', { name: /analyse a deal/i })).toHaveAttribute('href', '/analyse');
+    expect(screen.getByRole('link', { name: /view pricing/i })).toHaveAttribute('href', '/pricing');
+  });
+
+  it('renders safely without a session id', async () => {
+    render(await SuccessPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByRole('heading', { name: /checkout complete/i })).toBeInTheDocument();
+    expect(screen.getByText(/no checkout reference was included/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /go to account/i })).toHaveAttribute('href', '/account');
+  });
+});

--- a/frontend/app/success/page.tsx
+++ b/frontend/app/success/page.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+
+type SuccessPageProps = {
+  searchParams?: Promise<{
+    session_id?: string | string[];
+  }>;
+};
+
+function getSessionId(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] || null;
+  return value || null;
+}
+
+export const dynamic = 'force-dynamic';
+
+export default async function SuccessPage({ searchParams }: SuccessPageProps) {
+  const params = searchParams ? await searchParams : {};
+  const sessionId = getSessionId(params.session_id);
+
+  return (
+    <main className="mx-auto flex min-h-[70vh] max-w-3xl flex-col justify-center px-6 py-16">
+      <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm dark:border-slate-800 dark:bg-slate-950 sm:p-10">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-600 dark:text-brand-400">
+          Stripe checkout
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950 dark:text-slate-50">
+          Checkout complete
+        </h1>
+        <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-300">
+          Your subscription is being activated. This can take a few seconds while Stripe confirms the checkout and PropNexus updates your account.
+        </p>
+        <p className="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-400">
+          If your account still shows the previous plan, refresh the account page shortly. Entitlements are updated by the secure Stripe webhook, not by this return page.
+        </p>
+
+        {sessionId ? (
+          <p className="mt-5 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+            Checkout reference received.
+          </p>
+        ) : (
+          <p className="mt-5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-200">
+            No checkout reference was included, but you can still check your account status below.
+          </p>
+        )}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <Link href="/account" className="btn-primary justify-center">
+            Go to account
+          </Link>
+          <Link href="/analyse" className="btn-secondary justify-center">
+            Analyse a deal
+          </Link>
+          <Link href="/pricing" className="btn-secondary justify-center">
+            View pricing
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/PlanBadge.tsx
+++ b/frontend/components/PlanBadge.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { useUserPlan, UserPlan } from '@/lib/useUserPlan';
 import { isAuthEnabled } from '@/lib/auth';
+import { getPlanLabel } from '@/lib/planPermissions';
 
 interface PlanBadgeProps {
   /**
@@ -75,13 +76,15 @@ export default function PlanBadge({
 }
 
 function PlanBadgeNoAuth({ size, className = '' }: { size: 'sm' | 'md' | 'lg'; className?: string }) {
+  const label = getPlanLabel('free');
+
   return (
     <span
       className={`inline-flex items-center ${SIZE_CLASSES[size]} rounded-full border font-semibold ${PLAN_COLORS.free.bg} ${PLAN_COLORS.free.text} ${PLAN_COLORS.free.border} ${className}`}
       role="status"
-      aria-label="Current plan: free"
+      aria-label={`Current plan: ${label}`}
     >
-      <span className="capitalize">free</span>
+      <span>{label}</span>
     </span>
   );
 }
@@ -109,12 +112,13 @@ function PlanBadgeAuthed({
 
   // Get color scheme for current plan
   const colors = PLAN_COLORS[plan] || PLAN_COLORS.free;
+  const label = getPlanLabel(plan);
 
   return (
     <span
       className={`inline-flex items-center ${SIZE_CLASSES[size]} rounded-full border font-semibold ${colors.bg} ${colors.text} ${colors.border} ${className}`}
       role="status"
-      aria-label={`Current plan: ${plan}`}
+      aria-label={`Current plan: ${label}`}
     >
       {/* Plan icon */}
       {plan === 'investor' && (
@@ -142,7 +146,7 @@ function PlanBadgeAuthed({
         </svg>
       )}
 
-      <span className="capitalize">{plan}</span>
+      <span>{label}</span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary
Fixes the Stripe test checkout return flow by adding the missing App Router `/success` page that Stripe already redirects to after checkout. The page is intentionally safe: it reads the `session_id` from the URL, shows an activation-in-progress message, links users to Account / Analyse / Pricing, and does not expose or fetch Stripe session details client-side.

## Root Cause Of 404
Stripe checkout currently sends users to:

`{FRONTEND_URL or NEXT_PUBLIC_SITE_URL}/success?session_id={CHECKOUT_SESSION_ID}`

The frontend did not have `frontend/app/success/page.tsx`, so Next/Vercel returned 404 for `/success`. There was an older `frontend/app/success_page.tsx`, but that filename is not mounted as an App Router route.

## success_url Before / After
Before: backend checkout creation already built:

`/success?session_id={CHECKOUT_SESSION_ID}`

After: the same Stripe `success_url` is preserved, and `/success` now exists as a real frontend route. No pricing amounts were changed.

## Webhook Findings
- Backend webhook endpoint exists at `/stripe/webhook`.
- Signature verification remains in place via `stripe.Webhook.construct_event(...)`.
- Handled events include:
  - `checkout.session.completed`
  - `customer.subscription.created`
  - `customer.subscription.updated`
  - `customer.subscription.deleted`
- Frontend `/api/stripe/webhook` remains disabled and documents backend ownership.

## Plan Mapping Findings
- `STRIPE_PRICE_PRO` / `NEXT_PUBLIC_STRIPE_PRICE_PRO` maps to backend plan `pro`.
- `STRIPE_PRICE_INVESTOR` / `NEXT_PUBLIC_STRIPE_PRICE_INVESTOR` maps to backend plan `investor`.
- Public account labels now show:
  - `free` -> `Free`
  - `pro` -> `Investor Starter`
  - `investor` -> `Investor Pro`
- Unknown prices do not accidentally upgrade the user.
- Subscription deletion/cancelation downgrades to `free`.
- Trialing subscriptions are treated as eligible entitlement states.

## Tests Run
Targeted frontend:

`npm --prefix frontend test -- --runTestsByPath __tests__/api-stripe-checkout-route.spec.ts __tests__/api-stripe-create-checkout-session-route.spec.ts __tests__/account-page.spec.tsx __tests__/success-page.spec.tsx`

Targeted backend Stripe:

`python -m pytest backend/tests/test_stripe_webhook.py backend/tests/test_stripe_trial.py backend/tests/test_stripe_webhook_monitoring.py -q`

Full validation:

`python -m pytest backend/tests/ -q`

`npm --prefix frontend test -- --ci`

`npm --prefix frontend run lint`

`NEXT_TELEMETRY_DISABLED=1 NEXT_PRIVATE_BUILD_WORKER=1 npm --prefix frontend run build`

Result: all passed. Build emitted existing Next config/middleware warnings only.

## Stripe Dashboard Manual Checklist
In Stripe test mode, verify:

1. Developers -> Webhooks:
   - endpoint points to the production backend webhook URL
   - endpoint path matches the backend route, likely `/stripe/webhook`
2. Events listened to:
   - `checkout.session.completed`
   - `customer.subscription.created`
   - `customer.subscription.updated`
   - `customer.subscription.deleted`
3. Recent events:
   - find the `cs_test_...` checkout session
   - confirm webhook delivery status and response code
4. Products/prices:
   - Investor Starter/Pro test price IDs match environment variables
   - currency is GBP before public launch
5. Customer:
   - check `abbas_m90@hotmail.com`
   - subscription status is `trialing` or `active`
6. Metadata / identity:
   - current webhook identifies by Stripe customer/email; confirm customer email is present on the checkout/customer

## Confirmations
- No live Stripe switch.
- No Stripe secrets exposed.
- Webhook signature verification was not weakened.
- Pricing amounts were not changed.
- Sprint 2B was not started.
- Sprint 3 was not started.
- PR is not auto-merged.