### PR TITLE
fix(stripe): repair webhook plan activation

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -55,6 +55,12 @@ jobs:
         working-directory: frontend
         env:
           E2E_BASE_URL: "http://localhost:3000"
+          E2E_FREE_EMAIL: ${{ secrets.E2E_FREE_EMAIL }}
+          E2E_FREE_PASSWORD: ${{ secrets.E2E_FREE_PASSWORD }}
+          E2E_STARTER_EMAIL: ${{ secrets.E2E_STARTER_EMAIL }}
+          E2E_STARTER_PASSWORD: ${{ secrets.E2E_STARTER_PASSWORD }}
+          E2E_PRO_EMAIL: ${{ secrets.E2E_PRO_EMAIL }}
+          E2E_PRO_PASSWORD: ${{ secrets.E2E_PRO_PASSWORD }}
         run: |
           npx --yes @playwright/test@1.48.0 install --with-deps
           npx --yes @playwright/test@1.48.0 test --reporter=list

--- a/backend/routes/stripe_routes.py
+++ b/backend/routes/stripe_routes.py
@@ -78,6 +78,7 @@ def create_checkout_session(
     payload: CheckoutRequest,
     request: Request,
     x_propnexus_user_email: Optional[str] = Header(None, alias="X-PropNexus-User-Email"),
+    x_propnexus_user_id: Optional[str] = Header(None, alias="X-PropNexus-User-Id"),
 ):
     """
     Creates a Stripe Checkout Session with a 7-day trial.
@@ -101,6 +102,12 @@ def create_checkout_session(
         )
         if not price_id:
             raise HTTPException(status_code=400, detail="price_id or product_id is required")
+
+        clerk_user_id = str(x_propnexus_user_id or "").strip() or None
+        metadata = {
+            "email": email,
+            **({"clerk_user_id": clerk_user_id} if clerk_user_id else {}),
+        }
 
         # 1) Find existing customer in Stripe (mocked in tests)
         existing = stripe.Customer.search(query=f"email:'{email}'")
@@ -129,7 +136,8 @@ def create_checkout_session(
             mode="subscription",
             customer=customer_id,
             line_items=[{"price": price_id, "quantity": 1}],
-            subscription_data={"trial_period_days": 7},
+            metadata=metadata,
+            subscription_data={"trial_period_days": 7, "metadata": metadata},
             success_url=success_url + "?session_id={CHECKOUT_SESSION_ID}",
             cancel_url=cancel_url,
             allow_promotion_codes=True,

--- a/backend/routes/stripe_webhook.py
+++ b/backend/routes/stripe_webhook.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from typing import Any, Dict, Optional
@@ -25,12 +26,14 @@ router = APIRouter(prefix="/stripe", tags=["stripe"])
 def _monitor_webhook(
     message: str,
     *,
+    event_id: Optional[str] = None,
     level: str = "info",
     event_type: Optional[str] = None,
     customer_id: Optional[str] = None,
     subscription_id: Optional[str] = None,
     price_id: Optional[str] = None,
     mapped_plan: Optional[str] = None,
+    email_hash: Optional[str] = None,
     db_write_succeeded: Optional[bool] = None,
     failure_kind: Optional[str] = None,
 ) -> None:
@@ -38,11 +41,13 @@ def _monitor_webhook(
         message,
         level=level,
         stripe_webhook={
+            "event_id": event_id,
             "event_type": event_type,
             "customer_id": customer_id,
             "subscription_id": subscription_id,
             "price_id": price_id,
             "mapped_plan": mapped_plan,
+            "email_hash": email_hash,
             "db_write_succeeded": db_write_succeeded,
             "failure_kind": failure_kind,
         },
@@ -159,6 +164,64 @@ def _as_dict(obj: Any) -> Dict[str, Any]:
         return {}
 
 
+def _normalize_email(email: Optional[str]) -> Optional[str]:
+    value = str(email or "").strip().lower()
+    if not value or "@" not in value:
+        return None
+    return value
+
+
+def _email_hash(email: Optional[str]) -> Optional[str]:
+    normalized = _normalize_email(email)
+    if not normalized:
+        return None
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _response_has_rows(response: Any) -> bool:
+    data = getattr(response, "data", None)
+    if isinstance(data, list):
+        return len(data) > 0
+    if isinstance(data, dict):
+        return bool(data)
+    return False
+
+
+def _get_metadata(data_obj: Dict[str, Any]) -> Dict[str, Any]:
+    metadata = data_obj.get("metadata") or {}
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _customer_email(customer_id: Optional[str]) -> Optional[str]:
+    if not customer_id:
+        return None
+
+    try:
+        customer = stripe.Customer.retrieve(customer_id)
+        if isinstance(customer, dict):
+            return _normalize_email(customer.get("email"))
+        return _normalize_email(getattr(customer, "email", None))
+    except Exception as e:
+        logger.debug(f"Failed to retrieve customer email for {customer_id}: {e}")
+        return None
+
+
+def _resolve_checkout_email(data_obj: Dict[str, Any]) -> Optional[str]:
+    customer_details = data_obj.get("customer_details") or {}
+    metadata = _get_metadata(data_obj)
+
+    return (
+        _normalize_email(customer_details.get("email"))
+        or _normalize_email(data_obj.get("customer_email"))
+        or _normalize_email(metadata.get("email"))
+        or _customer_email(data_obj.get("customer"))
+    )
+
+
+def _entitlement_failure_response(failure_kind: str = "entitlement_write_failed") -> JSONResponse:
+    return JSONResponse({"ok": False, "error": failure_kind}, status_code=500)
+
+
 def _upsert_price_metadata(sb_client: Any, price_id: Optional[str]) -> bool:
     if not sb_client or not price_id:
         return True
@@ -197,6 +260,7 @@ def _upsert_subscription_record(
     status: Optional[str],
     price_id: Optional[str],
 ) -> bool:
+    email = _normalize_email(email)
     if not sb_client or not email:
         return True
 
@@ -213,7 +277,10 @@ def _upsert_subscription_record(
         sb_client.table("subscriptions").upsert(data, on_conflict="email").execute()
         return True
     except Exception as e:
-        logger.warning(f"Failed to upsert subscription record for {email}: {e}")
+        logger.warning(
+            "Failed to upsert subscription record",
+            extra={"email_hash": _email_hash(email), "error": str(e)},
+        )
         return False
 
 
@@ -227,7 +294,9 @@ def _write_user_plan(
     plan: Optional[str],
 ) -> bool:
     if not sb_client:
-        return True
+        return False
+
+    email = _normalize_email(email)
 
     base = {
         "stripe_customer_id": customer_id,
@@ -238,16 +307,28 @@ def _write_user_plan(
         base["plan"] = plan
 
     try:
-        # Unit tests historically expect a users-table upsert to occur even when email is None.
-        # In production, avoid attempting an insert that would violate NOT NULL on users.email.
-        if email or is_test_or_ci():
+        if email:
+            update_res = sb_client.table("users").update(base).eq("email", email).execute()
+            if _response_has_rows(update_res):
+                return True
+
             upsert_data = {**base, "email": email}
-            sb_client.table("users").upsert(upsert_data).execute()
+            sb_client.table("users").upsert(upsert_data, on_conflict="email").execute()
         elif customer_id:
             sb_client.table("users").update(base).eq("stripe_customer_id", customer_id).execute()
+        else:
+            return False
         return True
     except Exception as e:
-        logger.warning(f"Failed to write user plan data for customer {customer_id}: {e}")
+        logger.warning(
+            "Failed to write user plan data",
+            extra={
+                "customer_id": customer_id,
+                "email_hash": _email_hash(email),
+                "mapped_plan": plan,
+                "error": str(e),
+            },
+        )
         return False
 
 
@@ -341,13 +422,14 @@ async def stripe_webhook(request: Request):
         return JSONResponse({"ok": False, "error": "webhook_internal_error"}, status_code=500)
 
     etype = event.get("type")
+    event_id = event.get("id")
     data_obj: Dict[str, Any] = (event.get("data") or {}).get("object") or {}
 
     try:
         if etype == "checkout.session.completed":
             sub_id = data_obj.get("subscription")
             customer_id = data_obj.get("customer")
-            customer_email = (data_obj.get("customer_details") or {}).get("email")
+            customer_email = _resolve_checkout_email(data_obj)
 
             # In tests, these calls are patched
             sub = (
@@ -364,6 +446,21 @@ async def stripe_webhook(request: Request):
 
             # Map price_id to plan - returns None for unknown IDs
             plan = map_price_to_plan(price_id) if eligible_for_plan else None
+            if eligible_for_plan and not plan:
+                _monitor_webhook(
+                    "stripe_webhook_entitlement_write_failed",
+                    level="error",
+                    event_id=event_id,
+                    event_type=etype,
+                    customer_id=customer_id,
+                    subscription_id=sub_id,
+                    price_id=price_id,
+                    mapped_plan=plan,
+                    email_hash=_email_hash(customer_email),
+                    db_write_succeeded=False,
+                    failure_kind="unknown_price_id",
+                )
+                return _entitlement_failure_response("unknown_price_id")
             # Always preserve the real Stripe status
             plan_status = status
 
@@ -393,44 +490,92 @@ async def stripe_webhook(request: Request):
                         current_period_end=current_period_end,
                         plan=plan,
                     )
-                    db_write_succeeded = all([price_ok, sub_ok, user_ok])
-                    if not db_write_succeeded:
+                    optional_ok = all([price_ok, sub_ok])
+                    db_write_succeeded = user_ok
+                    if not optional_ok:
                         _monitor_webhook(
                             "stripe_webhook_partial_db_write",
                             level="warning",
+                            event_id=event_id,
                             event_type=etype,
                             customer_id=customer_id,
                             subscription_id=sub_id,
                             price_id=price_id,
                             mapped_plan=plan,
+                            email_hash=_email_hash(customer_email),
                             db_write_succeeded=False,
                             failure_kind="db_write_soft_failure",
                         )
+                    if not user_ok:
+                        _monitor_webhook(
+                            "stripe_webhook_entitlement_write_failed",
+                            level="error",
+                            event_id=event_id,
+                            event_type=etype,
+                            customer_id=customer_id,
+                            subscription_id=sub_id,
+                            price_id=price_id,
+                            mapped_plan=plan,
+                            email_hash=_email_hash(customer_email),
+                            db_write_succeeded=False,
+                            failure_kind="entitlement_write_failed",
+                        )
+                        return _entitlement_failure_response()
                 except Exception as e:
-                    # Log error but don't fail the webhook - gracefully skip DB write
-                    logger.warning(f"Failed to upsert user data in checkout.session.completed: {e}")
+                    logger.warning(
+                        "Failed to write checkout.session.completed entitlement data",
+                        extra={
+                            "event_id": event_id,
+                            "customer_id": customer_id,
+                            "subscription_id": sub_id,
+                            "price_id": price_id,
+                            "mapped_plan": plan,
+                            "email_hash": _email_hash(customer_email),
+                            "error": str(e),
+                        },
+                    )
                     db_write_succeeded = False
                     _monitor_webhook(
-                        "stripe_webhook_partial_db_write",
-                        level="warning",
+                        "stripe_webhook_entitlement_write_failed",
+                        level="error",
+                        event_id=event_id,
                         event_type=etype,
                         customer_id=customer_id,
                         subscription_id=sub_id,
                         price_id=price_id,
                         mapped_plan=plan,
+                        email_hash=_email_hash(customer_email),
                         db_write_succeeded=False,
                         failure_kind="db_write_exception",
                     )
-                    pass
+                    return _entitlement_failure_response()
+
+            if not sb_client:
+                _monitor_webhook(
+                    "stripe_webhook_entitlement_write_failed",
+                    level="error",
+                    event_id=event_id,
+                    event_type=etype,
+                    customer_id=customer_id,
+                    subscription_id=sub_id,
+                    price_id=price_id,
+                    mapped_plan=plan,
+                    email_hash=_email_hash(customer_email),
+                    db_write_succeeded=False,
+                    failure_kind="missing_supabase_client",
+                )
+                return _entitlement_failure_response()
 
             _monitor_webhook(
                 "stripe_webhook_processed",
                 level="info",
+                event_id=event_id,
                 event_type=etype,
                 customer_id=customer_id,
                 subscription_id=sub_id,
                 price_id=price_id,
                 mapped_plan=plan,
+                email_hash=_email_hash(customer_email),
                 db_write_succeeded=db_write_succeeded,
             )
 
@@ -445,21 +590,28 @@ async def stripe_webhook(request: Request):
             current_period_end = data_obj.get("current_period_end")
 
             # Retrieve customer email - handle potential failures gracefully
-            email = None
-            try:
-                if customer_id:
-                    customer = stripe.Customer.retrieve(customer_id)
-                    email = customer.get("email")
-            except Exception as e:
-                # If we can't retrieve customer email, continue without it
-                logger.debug(f"Failed to retrieve customer email for {customer_id}: {e}")
-                pass
+            email = _customer_email(customer_id)
 
             # Only treat certain statuses as eligible for a paid plan
             eligible_for_plan = status in ["active", "trialing", "past_due"]
 
             # Map price_id to plan - returns None for unknown IDs
             plan = map_price_to_plan(price_id) if eligible_for_plan else None
+            if eligible_for_plan and not plan:
+                _monitor_webhook(
+                    "stripe_webhook_entitlement_write_failed",
+                    level="error",
+                    event_id=event_id,
+                    event_type=etype,
+                    customer_id=customer_id,
+                    subscription_id=data_obj.get("id"),
+                    price_id=price_id,
+                    mapped_plan=plan,
+                    email_hash=_email_hash(email),
+                    db_write_succeeded=False,
+                    failure_kind="unknown_price_id",
+                )
+                return _entitlement_failure_response("unknown_price_id")
             # Always preserve the real Stripe status
             plan_status = status
 
@@ -487,44 +639,92 @@ async def stripe_webhook(request: Request):
                         current_period_end=current_period_end,
                         plan=plan,
                     )
-                    db_write_succeeded = all([price_ok, sub_ok, user_ok])
-                    if not db_write_succeeded:
+                    optional_ok = all([price_ok, sub_ok])
+                    db_write_succeeded = user_ok
+                    if not optional_ok:
                         _monitor_webhook(
                             "stripe_webhook_partial_db_write",
                             level="warning",
+                            event_id=event_id,
                             event_type=etype,
                             customer_id=customer_id,
                             subscription_id=data_obj.get("id"),
                             price_id=price_id,
                             mapped_plan=plan,
+                            email_hash=_email_hash(email),
                             db_write_succeeded=False,
                             failure_kind="db_write_soft_failure",
                         )
+                    if not user_ok:
+                        _monitor_webhook(
+                            "stripe_webhook_entitlement_write_failed",
+                            level="error",
+                            event_id=event_id,
+                            event_type=etype,
+                            customer_id=customer_id,
+                            subscription_id=data_obj.get("id"),
+                            price_id=price_id,
+                            mapped_plan=plan,
+                            email_hash=_email_hash(email),
+                            db_write_succeeded=False,
+                            failure_kind="entitlement_write_failed",
+                        )
+                        return _entitlement_failure_response()
                 except Exception as e:
-                    # Log error but don't fail the webhook - gracefully skip DB write
-                    logger.warning(f"Failed to upsert user data in subscription.updated: {e}")
+                    logger.warning(
+                        "Failed to write subscription.updated entitlement data",
+                        extra={
+                            "event_id": event_id,
+                            "customer_id": customer_id,
+                            "subscription_id": data_obj.get("id"),
+                            "price_id": price_id,
+                            "mapped_plan": plan,
+                            "email_hash": _email_hash(email),
+                            "error": str(e),
+                        },
+                    )
                     db_write_succeeded = False
                     _monitor_webhook(
-                        "stripe_webhook_partial_db_write",
-                        level="warning",
+                        "stripe_webhook_entitlement_write_failed",
+                        level="error",
+                        event_id=event_id,
                         event_type=etype,
                         customer_id=customer_id,
                         subscription_id=data_obj.get("id"),
                         price_id=price_id,
                         mapped_plan=plan,
+                        email_hash=_email_hash(email),
                         db_write_succeeded=False,
                         failure_kind="db_write_exception",
                     )
-                    pass
+                    return _entitlement_failure_response()
+
+            if not sb_client:
+                _monitor_webhook(
+                    "stripe_webhook_entitlement_write_failed",
+                    level="error",
+                    event_id=event_id,
+                    event_type=etype,
+                    customer_id=customer_id,
+                    subscription_id=data_obj.get("id"),
+                    price_id=price_id,
+                    mapped_plan=plan,
+                    email_hash=_email_hash(email),
+                    db_write_succeeded=False,
+                    failure_kind="missing_supabase_client",
+                )
+                return _entitlement_failure_response()
 
             _monitor_webhook(
                 "stripe_webhook_processed",
                 level="info",
+                event_id=event_id,
                 event_type=etype,
                 customer_id=customer_id,
                 subscription_id=data_obj.get("id"),
                 price_id=price_id,
                 mapped_plan=plan,
+                email_hash=_email_hash(email),
                 db_write_succeeded=db_write_succeeded,
             )
 
@@ -539,18 +739,26 @@ async def stripe_webhook(request: Request):
             current_period_end = data_obj.get("current_period_end")
 
             # Retrieve customer email - handle potential failures gracefully
-            email = None
-            try:
-                if customer_id:
-                    customer = stripe.Customer.retrieve(customer_id)
-                    email = customer.get("email")
-            except Exception as e:
-                # If we can't retrieve customer email, continue without it
-                logger.debug(f"Failed to retrieve customer email for {customer_id}: {e}")
-                pass
+            email = _customer_email(customer_id)
 
             # Map price_id to plan - returns None for unknown IDs
             plan = map_price_to_plan(price_id)
+            eligible_for_plan = status in ["active", "trialing", "past_due"]
+            if eligible_for_plan and not plan:
+                _monitor_webhook(
+                    "stripe_webhook_entitlement_write_failed",
+                    level="error",
+                    event_id=event_id,
+                    event_type=etype,
+                    customer_id=customer_id,
+                    subscription_id=data_obj.get("id"),
+                    price_id=price_id,
+                    mapped_plan=plan,
+                    email_hash=_email_hash(email),
+                    db_write_succeeded=False,
+                    failure_kind="unknown_price_id",
+                )
+                return _entitlement_failure_response("unknown_price_id")
             plan_status = (
                 status if status in ["active", "past_due", "canceled", "trialing"] else "active"
             )
@@ -579,44 +787,92 @@ async def stripe_webhook(request: Request):
                         current_period_end=current_period_end,
                         plan=plan,
                     )
-                    db_write_succeeded = all([price_ok, sub_ok, user_ok])
-                    if not db_write_succeeded:
+                    optional_ok = all([price_ok, sub_ok])
+                    db_write_succeeded = user_ok
+                    if not optional_ok:
                         _monitor_webhook(
                             "stripe_webhook_partial_db_write",
                             level="warning",
+                            event_id=event_id,
                             event_type=etype,
                             customer_id=customer_id,
                             subscription_id=data_obj.get("id"),
                             price_id=price_id,
                             mapped_plan=plan,
+                            email_hash=_email_hash(email),
                             db_write_succeeded=False,
                             failure_kind="db_write_soft_failure",
                         )
+                    if not user_ok:
+                        _monitor_webhook(
+                            "stripe_webhook_entitlement_write_failed",
+                            level="error",
+                            event_id=event_id,
+                            event_type=etype,
+                            customer_id=customer_id,
+                            subscription_id=data_obj.get("id"),
+                            price_id=price_id,
+                            mapped_plan=plan,
+                            email_hash=_email_hash(email),
+                            db_write_succeeded=False,
+                            failure_kind="entitlement_write_failed",
+                        )
+                        return _entitlement_failure_response()
                 except Exception as e:
-                    # Log error but don't fail the webhook - gracefully skip DB write
-                    logger.warning(f"Failed to upsert user data in subscription.created: {e}")
+                    logger.warning(
+                        "Failed to write subscription.created entitlement data",
+                        extra={
+                            "event_id": event_id,
+                            "customer_id": customer_id,
+                            "subscription_id": data_obj.get("id"),
+                            "price_id": price_id,
+                            "mapped_plan": plan,
+                            "email_hash": _email_hash(email),
+                            "error": str(e),
+                        },
+                    )
                     db_write_succeeded = False
                     _monitor_webhook(
-                        "stripe_webhook_partial_db_write",
-                        level="warning",
+                        "stripe_webhook_entitlement_write_failed",
+                        level="error",
+                        event_id=event_id,
                         event_type=etype,
                         customer_id=customer_id,
                         subscription_id=data_obj.get("id"),
                         price_id=price_id,
                         mapped_plan=plan,
+                        email_hash=_email_hash(email),
                         db_write_succeeded=False,
                         failure_kind="db_write_exception",
                     )
-                    pass
+                    return _entitlement_failure_response()
+
+            if not sb_client:
+                _monitor_webhook(
+                    "stripe_webhook_entitlement_write_failed",
+                    level="error",
+                    event_id=event_id,
+                    event_type=etype,
+                    customer_id=customer_id,
+                    subscription_id=data_obj.get("id"),
+                    price_id=price_id,
+                    mapped_plan=plan,
+                    email_hash=_email_hash(email),
+                    db_write_succeeded=False,
+                    failure_kind="missing_supabase_client",
+                )
+                return _entitlement_failure_response()
 
             _monitor_webhook(
                 "stripe_webhook_processed",
                 level="info",
+                event_id=event_id,
                 event_type=etype,
                 customer_id=customer_id,
                 subscription_id=data_obj.get("id"),
                 price_id=price_id,
                 mapped_plan=plan,
+                email_hash=_email_hash(email),
                 db_write_succeeded=db_write_succeeded,
             )
 
@@ -626,15 +882,7 @@ async def stripe_webhook(request: Request):
             customer_id = data_obj.get("customer")
 
             # Retrieve customer email - handle potential failures gracefully
-            email = None
-            try:
-                if customer_id:
-                    customer = stripe.Customer.retrieve(customer_id)
-                    email = customer.get("email")
-            except Exception as e:
-                # If we can't retrieve customer email, continue without it
-                logger.debug(f"Failed to retrieve customer email for {customer_id}: {e}")
-                pass
+            email = _customer_email(customer_id)
 
             # Get Supabase client (lazy, may be None)
             sb_client = get_supabase_client()
@@ -661,41 +909,85 @@ async def stripe_webhook(request: Request):
                         current_period_end=None,
                         plan="free",
                     )
-                    db_write_succeeded = all([sub_ok, user_ok])
-                    if not db_write_succeeded:
+                    db_write_succeeded = user_ok
+                    if not sub_ok:
                         _monitor_webhook(
                             "stripe_webhook_partial_db_write",
                             level="warning",
+                            event_id=event_id,
                             event_type=etype,
                             customer_id=customer_id,
                             subscription_id=data_obj.get("id"),
                             mapped_plan="free",
+                            email_hash=_email_hash(email),
                             db_write_succeeded=False,
                             failure_kind="db_write_soft_failure",
                         )
+                    if not user_ok:
+                        _monitor_webhook(
+                            "stripe_webhook_entitlement_write_failed",
+                            level="error",
+                            event_id=event_id,
+                            event_type=etype,
+                            customer_id=customer_id,
+                            subscription_id=data_obj.get("id"),
+                            mapped_plan="free",
+                            email_hash=_email_hash(email),
+                            db_write_succeeded=False,
+                            failure_kind="entitlement_write_failed",
+                        )
+                        return _entitlement_failure_response()
                 except Exception as e:
-                    # Log error but don't fail the webhook - gracefully skip DB write
-                    logger.warning(f"Failed to upsert user data in subscription.deleted: {e}")
+                    logger.warning(
+                        "Failed to write subscription.deleted entitlement data",
+                        extra={
+                            "event_id": event_id,
+                            "customer_id": customer_id,
+                            "subscription_id": data_obj.get("id"),
+                            "mapped_plan": "free",
+                            "email_hash": _email_hash(email),
+                            "error": str(e),
+                        },
+                    )
                     db_write_succeeded = False
                     _monitor_webhook(
-                        "stripe_webhook_partial_db_write",
-                        level="warning",
+                        "stripe_webhook_entitlement_write_failed",
+                        level="error",
+                        event_id=event_id,
                         event_type=etype,
                         customer_id=customer_id,
                         subscription_id=data_obj.get("id"),
                         mapped_plan="free",
+                        email_hash=_email_hash(email),
                         db_write_succeeded=False,
                         failure_kind="db_write_exception",
                     )
-                    pass
+                    return _entitlement_failure_response()
+
+            if not sb_client:
+                _monitor_webhook(
+                    "stripe_webhook_entitlement_write_failed",
+                    level="error",
+                    event_id=event_id,
+                    event_type=etype,
+                    customer_id=customer_id,
+                    subscription_id=data_obj.get("id"),
+                    mapped_plan="free",
+                    email_hash=_email_hash(email),
+                    db_write_succeeded=False,
+                    failure_kind="missing_supabase_client",
+                )
+                return _entitlement_failure_response()
 
             _monitor_webhook(
                 "stripe_webhook_processed",
                 level="info",
+                event_id=event_id,
                 event_type=etype,
                 customer_id=customer_id,
                 subscription_id=data_obj.get("id"),
                 mapped_plan="free",
+                email_hash=_email_hash(email),
                 db_write_succeeded=db_write_succeeded,
             )
 
@@ -705,6 +997,7 @@ async def stripe_webhook(request: Request):
         _monitor_webhook(
             "stripe_webhook_processed",
             level="info",
+            event_id=event_id,
             event_type=etype,
             customer_id=data_obj.get("customer"),
             subscription_id=data_obj.get("id"),
@@ -712,10 +1005,10 @@ async def stripe_webhook(request: Request):
         )
         return JSONResponse({"ok": True, "ignored": etype})
     except Exception as e:
-        # Keep 200 for tests; surface as ok=false so assertions can still read the result
         capture_exception(
             e,
             stripe_webhook={
+                "event_id": event_id,
                 "event_type": etype,
                 "customer_id": data_obj.get("customer"),
                 "subscription_id": data_obj.get("id"),
@@ -725,10 +1018,11 @@ async def stripe_webhook(request: Request):
         _monitor_webhook(
             "stripe_webhook_unexpected_exception",
             level="error",
+            event_id=event_id,
             event_type=etype,
             customer_id=data_obj.get("customer"),
             subscription_id=data_obj.get("id"),
             db_write_succeeded=False,
             failure_kind="unexpected_processing_exception",
         )
-        return JSONResponse({"ok": False, "error": str(e)})
+        return JSONResponse({"ok": False, "error": "webhook_processing_failed"}, status_code=500)

--- a/backend/scripts/reconcile_stripe_subscription.py
+++ b/backend/scripts/reconcile_stripe_subscription.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import stripe
+
+from backend.routes.stripe_webhook import (
+    _normalize_email,
+    _upsert_price_metadata,
+    _upsert_subscription_record,
+    _write_user_plan,
+    map_price_to_plan,
+)
+from backend.utils.supabase_client import get_supabase
+
+ELIGIBLE_STATUSES = {"active", "trialing", "past_due"}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    try:
+        return value.to_dict_recursive()
+    except Exception:
+        try:
+            return value.to_dict()
+        except Exception:
+            return {}
+
+
+def _customer_email(customer: Any) -> str | None:
+    data = _as_dict(customer)
+    return _normalize_email(data.get("email") or getattr(customer, "email", None))
+
+
+def _subscription_price_id(subscription: dict[str, Any]) -> str | None:
+    return (((subscription.get("items") or {}).get("data") or [{}])[0].get("price") or {}).get("id")
+
+
+def _retrieve_checkout_session(
+    session_id: str,
+) -> tuple[dict[str, Any], dict[str, Any], str | None]:
+    session = _as_dict(
+        stripe.checkout.Session.retrieve(
+            session_id,
+            expand=["subscription", "customer"],
+        )
+    )
+    subscription_value = session.get("subscription")
+    subscription = (
+        subscription_value
+        if isinstance(subscription_value, dict)
+        else _as_dict(stripe.Subscription.retrieve(subscription_value))
+    )
+    customer = session.get("customer")
+    email = _normalize_email((session.get("customer_details") or {}).get("email"))
+    email = email or _normalize_email(session.get("customer_email"))
+    email = email or _normalize_email((session.get("metadata") or {}).get("email"))
+    email = email or _customer_email(customer)
+    return session, subscription, email
+
+
+def _find_customer_by_email(email: str) -> dict[str, Any]:
+    results = stripe.Customer.search(query=f"email:'{email}'", limit=1)
+    data = getattr(results, "data", None) or []
+    if not data:
+        raise RuntimeError("No Stripe customer found for email")
+    return _as_dict(data[0])
+
+
+def _find_subscription_for_customer(customer_id: str) -> dict[str, Any]:
+    subscriptions = stripe.Subscription.list(customer=customer_id, status="all", limit=10)
+    items = [_as_dict(item) for item in (getattr(subscriptions, "data", None) or [])]
+    eligible = [item for item in items if item.get("status") in ELIGIBLE_STATUSES]
+    if eligible:
+        return eligible[0]
+    if items:
+        return items[0]
+    raise RuntimeError("No Stripe subscription found for customer")
+
+
+def _resolve(
+    args: argparse.Namespace,
+) -> tuple[dict[str, Any] | None, dict[str, Any], str | None, str | None]:
+    if args.checkout_session_id:
+        session, subscription, email = _retrieve_checkout_session(args.checkout_session_id)
+        customer = session.get("customer")
+        customer_id = customer.get("id") if isinstance(customer, dict) else customer
+        return session, subscription, customer_id, email
+
+    if args.customer_id:
+        customer = _as_dict(stripe.Customer.retrieve(args.customer_id))
+        subscription = _find_subscription_for_customer(args.customer_id)
+        return None, subscription, args.customer_id, _customer_email(customer)
+
+    if args.email:
+        email = _normalize_email(args.email)
+        if not email:
+            raise RuntimeError("A valid email is required")
+        customer = _find_customer_by_email(email)
+        customer_id = customer.get("id")
+        subscription = _find_subscription_for_customer(customer_id)
+        return None, subscription, customer_id, email
+
+    raise RuntimeError("Provide --email, --customer-id, or --checkout-session-id")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reconcile a Stripe subscription into Supabase users/subscriptions."
+    )
+    parser.add_argument("--email", help="Customer email to reconcile")
+    parser.add_argument("--customer-id", help="Stripe customer id to reconcile")
+    parser.add_argument("--checkout-session-id", help="Stripe checkout session id to reconcile")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and print the intended update without writing",
+    )
+    args = parser.parse_args()
+
+    secret = os.getenv("STRIPE_SECRET_KEY")
+    if not secret:
+        raise RuntimeError("STRIPE_SECRET_KEY is required")
+    stripe.api_key = secret
+
+    _session, subscription, customer_id, email = _resolve(args)
+    subscription_id = subscription.get("id")
+    status = subscription.get("status")
+    current_period_end = subscription.get("current_period_end")
+    price_id = _subscription_price_id(subscription)
+    plan = map_price_to_plan(price_id) if status in ELIGIBLE_STATUSES else None
+
+    result = {
+        "dry_run": args.dry_run,
+        "email": email,
+        "stripe_customer_id": customer_id,
+        "subscription_id": subscription_id,
+        "status": status,
+        "price_id": price_id,
+        "mapped_plan": plan,
+        "eligible_status": status in ELIGIBLE_STATUSES,
+    }
+
+    if status in ELIGIBLE_STATUSES and not plan:
+        result["ok"] = False
+        result["error"] = "unknown_price_id"
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 2
+
+    if args.dry_run:
+        result["ok"] = True
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
+    sb_client = get_supabase(required=True)
+    _upsert_price_metadata(sb_client, price_id)
+    _upsert_subscription_record(
+        sb_client,
+        email=email,
+        customer_id=customer_id,
+        subscription_id=subscription_id,
+        status=status,
+        price_id=price_id,
+    )
+    user_ok = _write_user_plan(
+        sb_client,
+        customer_id=customer_id,
+        email=email,
+        plan_status=status,
+        current_period_end=current_period_end,
+        plan=plan,
+    )
+    result["ok"] = user_ok
+    if not user_ok:
+        result["error"] = "entitlement_write_failed"
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(
+            json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True), file=sys.stderr
+        )
+        raise SystemExit(1)

--- a/backend/tests/test_stripe_trial.py
+++ b/backend/tests/test_stripe_trial.py
@@ -18,6 +18,7 @@ def client():
     os.environ["SUPABASE_URL"] = "https://fake.supabase.co"
     os.environ["SUPABASE_SERVICE_ROLE_KEY"] = "fake_key"
     os.environ["PROPNEXUS_INTERNAL_API_TOKEN"] = "test-internal-token"
+    os.environ["STRIPE_PRICE_PRO"] = "price_test"
 
     from backend.main import app
 
@@ -68,6 +69,11 @@ def test_checkout_session_includes_trial(mock_sb, mock_stripe, client):
 
     assert "subscription_data" in call_kwargs
     assert call_kwargs["subscription_data"]["trial_period_days"] == 7
+    assert call_kwargs["metadata"] == {"email": "test@example.com", "clerk_user_id": "user_test"}
+    assert call_kwargs["subscription_data"]["metadata"] == {
+        "email": "test@example.com",
+        "clerk_user_id": "user_test",
+    }
     assert call_kwargs["mode"] == "subscription"
     assert (
         call_kwargs["success_url"]

--- a/backend/tests/test_stripe_webhook.py
+++ b/backend/tests/test_stripe_webhook.py
@@ -17,10 +17,77 @@ def client():
     os.environ["STRIPE_SECRET_KEY"] = "sk_test_fake"
     os.environ["SUPABASE_URL"] = "https://fake.supabase.co"
     os.environ["SUPABASE_SERVICE_ROLE_KEY"] = "fake_key"
+    os.environ["STRIPE_PRICE_PRO"] = "price_test"
 
     from backend.main import app
 
     return TestClient(app)
+
+
+def _mock_supabase_tables(mock_supabase, *, user_update_rows=None, user_update_error=None):
+    users_table = Mock()
+    subscriptions_table = Mock()
+    prices_table = Mock()
+
+    user_execute = users_table.update.return_value.eq.return_value.execute
+    if user_update_error:
+        user_execute.side_effect = user_update_error
+    else:
+        user_execute.return_value = Mock(
+            data=user_update_rows if user_update_rows is not None else []
+        )
+    users_table.upsert.return_value.execute.return_value = Mock(data=[])
+
+    subscriptions_table.upsert.return_value.execute.return_value = Mock(data=[])
+    prices_table.upsert.return_value.execute.return_value = Mock(data=[])
+
+    def _table(name):
+        return {
+            "users": users_table,
+            "subscriptions": subscriptions_table,
+            "prices": prices_table,
+        }[name]
+
+    mock_supabase.table.side_effect = _table
+    return users_table, subscriptions_table, prices_table
+
+
+def _post_checkout_completed(client, mock_stripe, *, email_fields=None, price_id="price_pro_test"):
+    if email_fields is None:
+        email_fields = {"customer_details": {"email": "test@example.com"}}
+    mock_event = {
+        "id": "evt_checkout_test",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "customer": "cus_test",
+                "subscription": "sub_test",
+                **email_fields,
+            }
+        },
+    }
+    mock_stripe.Webhook.construct_event.return_value = mock_event
+    mock_stripe.Subscription.retrieve.return_value = {
+        "status": "trialing",
+        "items": {"data": [{"price": {"id": price_id}}]},
+        "current_period_end": 1234567890,
+    }
+    mock_stripe.Price.retrieve.return_value = {
+        "id": price_id,
+        "product": "prod_test",
+        "nickname": "Test price",
+        "unit_amount": 900,
+        "currency": "gbp",
+        "recurring": {"interval": "month"},
+    }
+
+    os.environ["STRIPE_PRICE_PRO"] = price_id
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    return client.post(
+        "/stripe/webhook",
+        data=json.dumps(mock_event),
+        headers={"Stripe-Signature": "test_sig"},
+    )
 
 
 def test_webhook_endpoint_exists(client):
@@ -94,9 +161,11 @@ def test_checkout_completed_event(mock_supabase, mock_stripe, client):
     assert response.json()["ok"] is True
 
 
+@patch("backend.routes.stripe_webhook.supabase")
 @patch("backend.routes.stripe_webhook.stripe")
-def test_subscription_updated_event(mock_stripe, client):
+def test_subscription_updated_event(mock_stripe, mock_supabase, client):
     """Test handling of subscription update event"""
+    _mock_supabase_tables(mock_supabase, user_update_rows=[{"id": "existing-user-id"}])
     mock_event = {
         "type": "customer.subscription.updated",
         "data": {
@@ -131,14 +200,8 @@ def test_webhook_secret_per_request(mock_stripe, client):
     os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_initial"
 
     mock_event = {
-        "type": "checkout.session.completed",
-        "data": {
-            "object": {
-                "customer": "cus_test",
-                "customer_details": {"email": "test@example.com"},
-                "subscription": None,
-            }
-        },
+        "type": "customer.created",
+        "data": {"object": {"id": "cus_test"}},
     }
 
     mock_stripe.Webhook.construct_event.return_value = mock_event
@@ -167,7 +230,7 @@ def test_webhook_secret_per_request(mock_stripe, client):
 @patch("backend.routes.stripe_webhook.supabase")
 @patch("backend.routes.stripe_webhook.stripe")
 def test_unknown_price_id_preserves_plan(mock_stripe, mock_supabase, client):
-    """Test that unknown price IDs do NOT overwrite existing plan to 'free'"""
+    """Unknown checkout price IDs do not grant entitlement and force a retry."""
     # Ensure no price mapping env vars are set
     for key in ["STRIPE_PRICE_PRO", "STRIPE_PRICE_INVESTOR", "STRIPE_PRICE_ENTERPRISE"]:
         if key in os.environ:
@@ -200,20 +263,137 @@ def test_unknown_price_id_preserves_plan(mock_stripe, mock_supabase, client):
         "/stripe/webhook", data=json.dumps(mock_event), headers={"Stripe-Signature": "test_sig"}
     )
 
+    assert response.status_code == 500
+    assert response.json() == {"ok": False, "error": "unknown_price_id"}
+    assert not mock_supabase.table.return_value.upsert.called
+
+
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_checkout_completed_updates_existing_user_by_normalized_email(
+    mock_stripe, mock_supabase, client
+):
+    users_table, _subscriptions_table, _prices_table = _mock_supabase_tables(
+        mock_supabase,
+        user_update_rows=[{"id": "existing-user-id", "email": "abbas_m90@hotmail.com"}],
+    )
+
+    response = _post_checkout_completed(
+        client,
+        mock_stripe,
+        email_fields={"customer_details": {"email": " Abbas_M90@HOTMAIL.COM "}},
+    )
+
     assert response.status_code == 200
     assert response.json()["ok"] is True
+    update_payload = users_table.update.call_args.args[0]
+    assert update_payload["plan"] == "pro"
+    assert update_payload["plan_status"] == "trialing"
+    users_table.update.return_value.eq.assert_called_with("email", "abbas_m90@hotmail.com")
+    assert not users_table.upsert.called
 
-    # Verify upsert was called
-    assert mock_supabase.table.return_value.upsert.called
 
-    # Get the upsert data
-    upsert_call = mock_supabase.table.return_value.upsert.call_args[0][0]
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_checkout_completed_upserts_on_email_conflict_when_no_existing_row(
+    mock_stripe, mock_supabase, client
+):
+    users_table, _subscriptions_table, _prices_table = _mock_supabase_tables(
+        mock_supabase,
+        user_update_rows=[],
+    )
 
-    # Verify that 'plan' field is NOT in the upsert data (preserving existing plan)
-    assert "plan" not in upsert_call, "Unknown price ID should not set plan field"
-    # But other fields should be present
-    assert "stripe_customer_id" in upsert_call
-    assert "plan_status" in upsert_call
+    response = _post_checkout_completed(
+        client,
+        mock_stripe,
+        email_fields={"customer_email": "New_User@Example.COM"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    users_table.upsert.assert_called_once()
+    upsert_payload = users_table.upsert.call_args.args[0]
+    assert upsert_payload["email"] == "new_user@example.com"
+    assert upsert_payload["plan"] == "pro"
+    assert users_table.upsert.call_args.kwargs["on_conflict"] == "email"
+
+
+@pytest.mark.parametrize(
+    ("email_fields", "expected_email"),
+    [
+        ({"customer_email": "customer-email@example.com"}, "customer-email@example.com"),
+        ({"metadata": {"email": "metadata-email@example.com"}}, "metadata-email@example.com"),
+        ({}, "customer-retrieve@example.com"),
+    ],
+)
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_checkout_completed_email_fallbacks(
+    mock_stripe, mock_supabase, client, email_fields, expected_email
+):
+    users_table, _subscriptions_table, _prices_table = _mock_supabase_tables(
+        mock_supabase,
+        user_update_rows=[{"id": "existing-user-id", "email": expected_email}],
+    )
+    mock_stripe.Customer.retrieve.return_value = {"email": "customer-retrieve@example.com"}
+
+    response = _post_checkout_completed(client, mock_stripe, email_fields=email_fields)
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    users_table.update.return_value.eq.assert_called_with("email", expected_email)
+
+
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_checkout_completed_required_user_write_failure_returns_500(
+    mock_stripe, mock_supabase, client
+):
+    _mock_supabase_tables(mock_supabase, user_update_error=Exception("duplicate email"))
+
+    response = _post_checkout_completed(client, mock_stripe)
+
+    assert response.status_code == 500
+    assert response.json() == {"ok": False, "error": "entitlement_write_failed"}
+
+
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_subscription_deleted_updates_existing_user_without_replacing_id(
+    mock_stripe, mock_supabase, client
+):
+    users_table, _subscriptions_table, _prices_table = _mock_supabase_tables(
+        mock_supabase,
+        user_update_rows=[{"id": "existing-user-id", "email": "downgrade@example.com"}],
+    )
+    mock_event = {
+        "id": "evt_deleted_test",
+        "type": "customer.subscription.deleted",
+        "data": {
+            "object": {
+                "id": "sub_deleted_test",
+                "customer": "cus_deleted_test",
+                "status": "canceled",
+            }
+        },
+    }
+    mock_stripe.Webhook.construct_event.return_value = mock_event
+    mock_stripe.Customer.retrieve.return_value = {"email": "downgrade@example.com"}
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+
+    response = client.post(
+        "/stripe/webhook",
+        data=json.dumps(mock_event),
+        headers={"Stripe-Signature": "test_sig"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    update_payload = users_table.update.call_args.args[0]
+    assert update_payload["plan"] == "free"
+    assert update_payload["plan_status"] == "canceled"
+    users_table.update.return_value.eq.assert_called_with("email", "downgrade@example.com")
+    assert not users_table.upsert.called
 
 
 @patch("backend.routes.stripe_webhook.stripe")
@@ -230,12 +410,17 @@ def test_graceful_handling_no_supabase(mock_stripe, client):
             "object": {
                 "customer": "cus_test",
                 "customer_details": {"email": "test@example.com"},
-                "subscription": None,
+                "subscription": "sub_test",
             }
         },
     }
 
     mock_stripe.Webhook.construct_event.return_value = mock_event
+    mock_stripe.Subscription.retrieve.return_value = {
+        "status": "active",
+        "items": {"data": [{"price": {"id": "price_test"}}]},
+        "current_period_end": 1234567890,
+    }
 
     os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
 
@@ -243,9 +428,8 @@ def test_graceful_handling_no_supabase(mock_stripe, client):
         "/stripe/webhook", data=json.dumps(mock_event), headers={"Stripe-Signature": "test_sig"}
     )
 
-    # Should succeed gracefully without Supabase
-    assert response.status_code == 200
-    assert response.json()["ok"] is True
+    assert response.status_code == 500
+    assert response.json() == {"ok": False, "error": "entitlement_write_failed"}
 
     # Restore env vars for other tests
     os.environ["SUPABASE_URL"] = "https://fake.supabase.co"
@@ -282,14 +466,8 @@ def test_subscription_updated_email_retrieval_failure(mock_stripe, mock_supabase
         "/stripe/webhook", data=json.dumps(mock_event), headers={"Stripe-Signature": "test_sig"}
     )
 
-    # Should succeed despite email retrieval failure
     assert response.status_code == 200
     assert response.json()["ok"] is True
-
-    # Verify upsert was still called (with email=None)
-    assert mock_supabase.table.return_value.upsert.called
-    upsert_data = mock_supabase.table.return_value.upsert.call_args[0][0]
-    assert upsert_data["email"] is None
 
 
 @patch("backend.routes.stripe_webhook.supabase")

--- a/backend/tests/test_stripe_webhook_monitoring.py
+++ b/backend/tests/test_stripe_webhook_monitoring.py
@@ -12,6 +12,7 @@ def client():
     os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
     os.environ["SUPABASE_URL"] = "https://fake.supabase.co"
     os.environ["SUPABASE_SERVICE_ROLE_KEY"] = "fake_key"
+    os.environ["STRIPE_PRICE_PRO"] = "price_test_123"
 
     from backend.main import app
 
@@ -40,6 +41,13 @@ def test_webhook_success_instrumentation(
         "status": "active",
         "items": {"data": [{"price": {"id": "price_test_123"}}]},
         "current_period_end": 1234567890,
+    }
+    mock_stripe.Price.retrieve.return_value = {
+        "product": "prod_test",
+        "nickname": "Test price",
+        "unit_amount": 900,
+        "currency": "gbp",
+        "recurring": {"interval": "month"},
     }
     mock_supabase.table.return_value.upsert.return_value.execute.return_value = Mock(data=[])
 
@@ -143,6 +151,14 @@ def test_webhook_partial_db_write_soft_failure_instrumentation(
     mock_stripe.Webhook.construct_event.return_value = mock_event
     mock_stripe.Customer.retrieve.return_value = {"email": "soft@example.com"}
 
+    os.environ["STRIPE_PRICE_PRO"] = "price_soft_1"
+    mock_stripe.Price.retrieve.return_value = {
+        "product": "prod_test",
+        "nickname": "Soft price",
+        "unit_amount": 900,
+        "currency": "gbp",
+        "recurring": {"interval": "month"},
+    }
     mock_supabase.table.return_value.upsert.return_value.execute.side_effect = Exception("db down")
 
     response = client.post(
@@ -151,12 +167,12 @@ def test_webhook_partial_db_write_soft_failure_instrumentation(
         headers={"Stripe-Signature": "sig_test"},
     )
 
-    assert response.status_code == 200
-    assert response.json()["ok"] is True
+    assert response.status_code == 500
+    assert response.json() == {"ok": False, "error": "entitlement_write_failed"}
     partial_calls = [
         call
         for call in mock_capture_message.call_args_list
-        if call.args and call.args[0] == "stripe_webhook_partial_db_write"
+        if call.args and call.args[0] == "stripe_webhook_entitlement_write_failed"
     ]
     assert partial_calls
     partial_ctx = partial_calls[-1].kwargs.get("stripe_webhook", {})
@@ -190,7 +206,7 @@ def test_webhook_unexpected_exception_instrumentation(
         headers={"Stripe-Signature": "sig_test"},
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 500
     assert response.json()["ok"] is False
 
     assert mock_capture_exception.called

--- a/backend/tests/test_users_plan_investor.py
+++ b/backend/tests/test_users_plan_investor.py
@@ -92,7 +92,7 @@ def test_webhook_investor_plan_checkout():
 
                     second_call = mock_table.upsert.call_args_list[1]
                     second_payload = second_call.args[0]
-                    assert "on_conflict" not in second_call.kwargs
+                    assert second_call.kwargs.get("on_conflict") == "email"
                     assert second_payload["plan"] == "investor"
                     assert second_payload["plan_status"] == "active"
                     assert second_payload["current_period_end"] == 1735689600
@@ -191,13 +191,10 @@ def test_webhook_unknown_price_preserves_existing_plan():
                         headers={"Stripe-Signature": "test_sig"},
                     )
 
-                    assert response.status_code == 200
+                    assert response.status_code == 500
                     data = response.json()
-                    assert data["ok"] is True
-
-                    call_args = mock_table.upsert.call_args[0][0]
-                    # Unknown price_id should NOT set plan field (preserves existing plan)
-                    assert "plan" not in call_args
+                    assert data == {"ok": False, "error": "unknown_price_id"}
+                    assert not mock_table.upsert.called
 
 
 def test_users_plan_endpoint_returns_investor():

--- a/frontend/__tests__/success-page.spec.tsx
+++ b/frontend/__tests__/success-page.spec.tsx
@@ -3,6 +3,9 @@ import SuccessPage from '@/app/success/page';
 
 describe('/success page', () => {
   it('renders a safe checkout-complete state with a session id', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn() as any;
+
     render(await SuccessPage({ searchParams: Promise.resolve({ session_id: 'cs_test_123' }) }));
 
     expect(screen.getByRole('heading', { name: /checkout complete/i })).toBeInTheDocument();
@@ -10,6 +13,8 @@ describe('/success page', () => {
     expect(screen.getByRole('link', { name: /go to account/i })).toHaveAttribute('href', '/account');
     expect(screen.getByRole('link', { name: /analyse a deal/i })).toHaveAttribute('href', '/analyse');
     expect(screen.getByRole('link', { name: /view pricing/i })).toHaveAttribute('href', '/pricing');
+    expect(global.fetch).not.toHaveBeenCalled();
+    global.fetch = originalFetch;
   });
 
   it('renders safely without a session id', async () => {

--- a/frontend/__tests__/useUserPlan.spec.tsx
+++ b/frontend/__tests__/useUserPlan.spec.tsx
@@ -1,0 +1,37 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useUserPlan } from '@/lib/useUserPlan';
+
+jest.mock('@/lib/auth', () => ({
+  isAuthEnabled: true,
+}));
+
+describe('useUserPlan', () => {
+  const oldFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = oldFetch;
+  });
+
+  it('loads the current plan from /api/users/plan', async () => {
+    global.fetch = jest.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ plan: 'investor' }),
+      };
+    }) as any;
+
+    const { result } = renderHook(() => useUserPlan());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/users/plan',
+      expect.objectContaining({
+        method: 'GET',
+        cache: 'no-store',
+      }),
+    );
+    expect(result.current.plan).toBe('investor');
+  });
+});

--- a/frontend/e2e/production-smoke.spec.ts
+++ b/frontend/e2e/production-smoke.spec.ts
@@ -16,10 +16,23 @@ const listingText = [
 const screenshotDir = path.resolve(process.cwd(), '../docs/screenshots');
 
 type PlanKey = 'free' | 'starter' | 'pro';
+type BackendPlan = 'free' | 'pro' | 'investor';
 
 type Credentials = {
   email: string;
   password: string;
+};
+
+const expectedBackendPlan: Record<PlanKey, BackendPlan> = {
+  free: 'free',
+  starter: 'pro',
+  pro: 'investor',
+};
+
+const credentialEnvNames: Record<PlanKey, string> = {
+  free: 'E2E_FREE_EMAIL/E2E_FREE_PASSWORD',
+  starter: 'E2E_STARTER_EMAIL/E2E_STARTER_PASSWORD',
+  pro: 'E2E_PRO_EMAIL/E2E_PRO_PASSWORD',
 };
 
 function getCredentials(plan: PlanKey): Credentials | null {
@@ -27,6 +40,12 @@ function getCredentials(plan: PlanKey): Credentials | null {
   const email = (process.env[`${prefix}_EMAIL`] ?? '').trim();
   const password = (process.env[`${prefix}_PASSWORD`] ?? '').trim();
   return email && password ? { email, password } : null;
+}
+
+function skipIfMissingCredentials(plan: PlanKey): Credentials {
+  const credentials = getCredentials(plan);
+  test.skip(!credentials, `Authenticated smoke skipped: missing ${credentialEnvNames[plan]} secrets.`);
+  return credentials!;
 }
 
 async function captureScreenshot(page: Page, name: string) {
@@ -43,6 +62,21 @@ async function signIn(page: Page, credentials: Credentials, redirectPath = '/ana
   await page.getByPlaceholder(/enter your password/i).fill(credentials.password);
   await page.getByRole('button', { name: /^continue$/i }).click();
   await page.waitForURL((url) => !url.pathname.startsWith('/sign-in'), { timeout: 30_000 });
+}
+
+async function confirmAuthenticatedPlan(page: Page, expectedPlan: BackendPlan) {
+  const response = await page.context().request.get('/api/users/plan', {
+    headers: { accept: 'application/json' },
+  });
+  expect(response.status()).toBe(200);
+  const payload = (await response.json()) as { plan?: unknown };
+  expect(payload.plan).toBe(expectedPlan);
+}
+
+async function signInAndConfirmPlan(page: Page, plan: PlanKey, redirectPath = '/analyse') {
+  const credentials = skipIfMissingCredentials(plan);
+  await signIn(page, credentials, redirectPath);
+  await confirmAuthenticatedPlan(page, expectedBackendPlan[plan]);
 }
 
 async function fillAnalyseForm(page: Page) {
@@ -80,6 +114,8 @@ async function fillAnalyseForm(page: Page) {
   await expect(page.getByLabel(/asking price/i)).toHaveValue('250000');
   expect(sourceRequests).toEqual([]);
 }
+
+test.use({ trace: 'off', screenshot: 'off', video: 'off' });
 
 test.describe('production smoke anonymous', () => {
   test('analyse, free public Deal Pack/PDF, and pricing checks', async ({ page, request }) => {
@@ -157,11 +193,8 @@ test.describe('production smoke anonymous', () => {
 
 test.describe('production smoke authenticated', () => {
   test('free account can submit analyse flow but remains locked out of Deal Pack and PDF', async ({ page }) => {
-    const credentials = getCredentials('free');
-    test.skip(!credentials, 'Missing E2E_FREE_EMAIL/E2E_FREE_PASSWORD');
-
     await page.setViewportSize({ width: 1440, height: 1600 });
-    await signIn(page, credentials!, '/analyse');
+    await signInAndConfirmPlan(page, 'free', '/analyse');
     await fillAnalyseForm(page);
 
     await page.getByRole('button', { name: /generate deal pack/i }).click();
@@ -181,10 +214,7 @@ test.describe('production smoke authenticated', () => {
   });
 
   test('starter account keeps full Deal Pack and PDF locked', async ({ page }) => {
-    const credentials = getCredentials('starter');
-    test.skip(!credentials, 'Missing E2E_STARTER_EMAIL/E2E_STARTER_PASSWORD');
-
-    await signIn(page, credentials!, `/property/${publicPropertyId}`);
+    await signInAndConfirmPlan(page, 'starter', `/property/${publicPropertyId}`);
     await page.goto(`/property/${publicPropertyId}`, { waitUntil: 'domcontentloaded' });
     await expect(page.locator('body')).toContainText(/offer range preview|starter offer range|unlock investor pro/i);
 
@@ -197,10 +227,7 @@ test.describe('production smoke authenticated', () => {
   });
 
   test('pro account can open the full Deal Pack and download PDF', async ({ page }) => {
-    const credentials = getCredentials('pro');
-    test.skip(!credentials, 'Missing E2E_PRO_EMAIL/E2E_PRO_PASSWORD');
-
-    await signIn(page, credentials!, `/property/${publicPropertyId}`);
+    await signInAndConfirmPlan(page, 'pro', `/property/${publicPropertyId}`);
 
     await page.goto(`/property/${publicPropertyId}/deal-pack`, { waitUntil: 'domcontentloaded' });
     await expect(page.locator('[data-deal-pack-root]')).toBeVisible({ timeout: 30_000 });

--- a/frontend/playwright.production.config.ts
+++ b/frontend/playwright.production.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
   reporter: 'list',
   use: {
     baseURL: BASE_URL,
-    trace: 'on-first-retry',
+    trace: 'off',
+    screenshot: 'off',
+    video: 'off',
   },
   projects: [
     {


### PR DESCRIPTION
## Summary
Fixes webhook entitlement persistence for successful Stripe test subscriptions that redirected to `/success` but left the authenticated account on Free.

Observed production behavior: checkout/trial completed for `abbas_m90@hotmail.com`, `/success?session_id=cs_test_...` loaded, but `/account` still showed Free after refresh. This PR does not manually grant entitlement; it fixes the webhook persistence path and adds a reconciliation tool for diagnosed missed events.

## Exact Root Cause
The webhook wrote `public.users` with:

`sb_client.table("users").upsert(upsert_data).execute()`

without `on_conflict="email"`, while the schema has `public.users.email text unique not null`. For an existing Clerk-created user row, a webhook write by email could fail on duplicate email or fail to target the existing row correctly.

The webhook then swallowed database write failures and still returned HTTP 200 / `{ "ok": true }`, which prevented Stripe retries and hid entitlement failures.

## Duplicate Email Conflict Confirmation
Confirmed from schema:

- `public.users.email text unique not null`
- `public.subscriptions.email text unique not null`

The old users-table write did not specify the email conflict target. The new write path normalizes email, updates an existing user by email first, then falls back to `upsert(..., on_conflict="email")` if no row is updated.

## Old vs New Webhook HTTP Behavior
Old behavior:

- Signature-valid event + users entitlement DB write failure -> HTTP 200 / `{ "ok": true }`
- Unknown active/trialing price could leave the user Free while the event was acknowledged

New behavior:

- Signature-valid event + successful required users-plan write -> HTTP 200
- Signature-valid event + required users-plan write failure -> HTTP 500 / `{ "ok": false, "error": "entitlement_write_failed" }`
- Eligible active/trialing/past_due subscription with unknown price -> HTTP 500 / `{ "ok": false, "error": "unknown_price_id" }`

This allows Stripe to retry instead of permanently acknowledging a failed entitlement write. Optional price/subscription analytics writes remain non-blocking.

## Identity Fallback Logic
For `checkout.session.completed`, email now resolves safely in this order:

1. `customer_details.email`
2. `customer_email`
3. `metadata.email`
4. retrieved Stripe Customer `email`

Emails are normalized with `strip().lower()` before Supabase writes.

Checkout creation now attaches trusted server-side identity metadata from authenticated frontend-proxy headers:

- checkout session `metadata.email`
- checkout session `metadata.clerk_user_id`
- subscription `metadata.email`
- subscription `metadata.clerk_user_id`

These values are not trusted from arbitrary browser body payloads.

## Plan Mapping Verification
Expected mapping remains unchanged:

- `STRIPE_PRICE_PRO` / `NEXT_PUBLIC_STRIPE_PRICE_PRO` -> backend plan `pro` / public label `Investor Starter`
- `STRIPE_PRICE_INVESTOR` / `NEXT_PUBLIC_STRIPE_PRICE_INVESTOR` -> backend plan `investor` / public label `Investor Pro`
- deleted subscription -> `free`

Unknown eligible prices do not grant entitlement and now return a retryable server error so configuration drift is visible.

## Reconciliation Instructions
Dry run first:

```bash
python -m backend.scripts.reconcile_stripe_subscription \
  --email abbas_m90@hotmail.com \
  --dry-run
```

Then, only if the dry-run output shows the expected customer/subscription/status/price/plan:

```bash
python -m backend.scripts.reconcile_stripe_subscription \
  --email abbas_m90@hotmail.com
```

The local dry-run in the dev container was blocked because `STRIPE_SECRET_KEY` is not present locally. Run it in Railway or another secure backend shell with test-mode Stripe and Supabase service-role environment variables available. Do not paste secrets into output or GitHub.

## Tests Run
Focused backend Stripe:

`python -m pytest backend/tests/test_stripe_webhook.py backend/tests/test_stripe_trial.py backend/tests/test_stripe_webhook_monitoring.py -q`

Full backend:

`python -m pytest backend/tests/ -q`

Focused frontend entitlement/source tests:

`npm --prefix frontend test -- --runTestsByPath __tests__/account-page.spec.tsx __tests__/success-page.spec.tsx __tests__/useUserPlan.spec.tsx __tests__/api-users-plan-route.spec.ts`

Full frontend:

`npm --prefix frontend test -- --ci`

Lint:

`npm --prefix frontend run lint`

Build:

`NEXT_TELEMETRY_DISABLED=1 NEXT_PRIVATE_BUILD_WORKER=1 npm --prefix frontend run build`

The build command was attempted twice in the dev container and was terminated with exit 143 after `Creating an optimized production build ...`, before `.next/BUILD_ID` was generated. Tests and lint passed; CI should provide the definitive production build result.

## Manual Production Diagnostic Checklist
Stripe test mode:

1. Find checkout session for `abbas_m90@hotmail.com`.
2. Confirm payment/trial status, subscription id, customer id, actual price id, and customer email.
3. Developers -> Events: inspect `checkout.session.completed`, `customer.subscription.created`, and `customer.subscription.updated`.
4. Developers -> Webhooks: confirm production backend delivery endpoint, response status/body, retry count, and timestamp.
5. Confirm webhook endpoint is `<production-backend-url>/stripe/webhook`.

Railway:

- Confirm env vars exist: `STRIPE_WEBHOOK_SECRET`, `STRIPE_SECRET_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `STRIPE_PRICE_PRO`, `STRIPE_PRICE_INVESTOR`.
- Inspect logs for `mapped_plan`, `db_write_succeeded`, duplicate email errors, missing Supabase credentials, unknown price id, or missing webhook secret.

Supabase:

- Inspect `public.users` row where `email = 'abbas_m90@hotmail.com'`.
- Check `plan`, `plan_status`, `stripe_customer_id`, `current_period_end`, `updated_at`.
- Inspect `public.subscriptions` for the same normalized email.

## Confirmations
- Stripe webhook signature verification remains enabled and unchanged.
- No Stripe secrets exposed.
- Pricing amounts unchanged.
- No live-mode switch.
- Sprint 2B not started.
- Sprint 3 not started.
- PR is not auto-merged.