### PR TITLE
fix(stripe): support Stripe object payloads and unblock smoke tests

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -124,5 +124,6 @@ jobs:
           E2E_PRO_EMAIL: ${{ secrets.E2E_PRO_EMAIL }}
           E2E_PRO_PASSWORD: ${{ secrets.E2E_PRO_PASSWORD }}
         run: |
-          npx --yes @playwright/test@1.48.0 install --with-deps
-          npx --yes @playwright/test@1.48.0 test --config=playwright.production.config.ts --reporter=list
+          npx playwright install --with-deps chromium
+          npx playwright test e2e/production-smoke.spec.ts --config=playwright.production.config.ts --list
+          npx playwright test e2e/production-smoke.spec.ts --config=playwright.production.config.ts --reporter=list

--- a/backend/routes/stripe_webhook.py
+++ b/backend/routes/stripe_webhook.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+from collections.abc import Mapping, Sequence
 from typing import Any, Dict, Optional
 
 import stripe
@@ -22,6 +23,9 @@ supabase = None  # will be monkeypatched by tests
 
 router = APIRouter(prefix="/stripe", tags=["stripe"])
 
+ELIGIBLE_STATUSES = {"active", "trialing", "past_due"}
+TERMINAL_STATUSES = {"canceled", "incomplete_expired", "unpaid"}
+
 
 def _monitor_webhook(
     message: str,
@@ -30,12 +34,16 @@ def _monitor_webhook(
     level: str = "info",
     event_type: Optional[str] = None,
     customer_id: Optional[str] = None,
+    object_id: Optional[str] = None,
     subscription_id: Optional[str] = None,
+    subscription_status: Optional[str] = None,
     price_id: Optional[str] = None,
     mapped_plan: Optional[str] = None,
     email_hash: Optional[str] = None,
     db_write_succeeded: Optional[bool] = None,
     failure_kind: Optional[str] = None,
+    exception_type: Optional[str] = None,
+    result: Optional[str] = None,
 ) -> None:
     capture_message(
         message,
@@ -44,12 +52,16 @@ def _monitor_webhook(
             "event_id": event_id,
             "event_type": event_type,
             "customer_id": customer_id,
+            "object_id": object_id,
             "subscription_id": subscription_id,
+            "subscription_status": subscription_status,
             "price_id": price_id,
             "mapped_plan": mapped_plan,
             "email_hash": email_hash,
             "db_write_succeeded": db_write_succeeded,
             "failure_kind": failure_kind,
+            "exception_type": exception_type,
+            "result": result,
         },
     )
 
@@ -116,9 +128,7 @@ def map_price_to_plan(price_id: str) -> Optional[str]:
     try:
         _ensure_stripe_api_key()
         price = stripe.Price.retrieve(price_id)
-        product_id = (
-            price.get("product") if isinstance(price, dict) else getattr(price, "product", None)
-        )
+        product_id = _stripe_value(price, "product")
         return product_to_plan.get(product_id)
     except Exception as exc:
         logger.warning(
@@ -164,6 +174,55 @@ def _as_dict(obj: Any) -> Dict[str, Any]:
         return {}
 
 
+def _stripe_value(value: Any, key: str, default: Any = None) -> Any:
+    """Read a Stripe field from mappings or StripeObject-style attributes."""
+    if value is None:
+        return default
+
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+
+    try:
+        return getattr(value, key)
+    except (AttributeError, TypeError):
+        pass
+
+    try:
+        return value[key]
+    except (KeyError, IndexError, TypeError, AttributeError):
+        return default
+
+
+def _stripe_object_id(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        return value
+    object_id = _stripe_value(value, "id")
+    return str(object_id) if object_id else None
+
+
+def _stripe_list_data(value: Any) -> list[Any]:
+    data = _stripe_value(value, "data", [])
+    if isinstance(data, Sequence) and not isinstance(data, (str, bytes, bytearray)):
+        return list(data)
+    return []
+
+
+def _subscription_price_id(subscription: Any) -> Optional[str]:
+    items = _stripe_value(subscription, "items", {})
+    first_item = (_stripe_list_data(items) or [{}])[0]
+    price = _stripe_value(first_item, "price", {})
+    return _stripe_object_id(price)
+
+
+def _subscription_metadata_email(subscription: Any) -> Optional[str]:
+    metadata = _stripe_value(subscription, "metadata", {})
+    return _normalize_email(_stripe_value(metadata, "email"))
+
+
+def _event_data_object(event: Any) -> Any:
+    return _stripe_value(_stripe_value(event, "data", {}), "object", {}) or {}
+
+
 def _normalize_email(email: Optional[str]) -> Optional[str]:
     value = str(email or "").strip().lower()
     if not value or "@" not in value:
@@ -187,35 +246,211 @@ def _response_has_rows(response: Any) -> bool:
     return False
 
 
-def _get_metadata(data_obj: Dict[str, Any]) -> Dict[str, Any]:
-    metadata = data_obj.get("metadata") or {}
-    return metadata if isinstance(metadata, dict) else {}
+def _customer_email(customer_value: Any) -> Optional[str]:
+    expanded_email = _normalize_email(_stripe_value(customer_value, "email"))
+    if expanded_email:
+        return expanded_email
 
-
-def _customer_email(customer_id: Optional[str]) -> Optional[str]:
+    customer_id = _stripe_object_id(customer_value)
     if not customer_id:
         return None
 
     try:
         customer = stripe.Customer.retrieve(customer_id)
-        if isinstance(customer, dict):
-            return _normalize_email(customer.get("email"))
-        return _normalize_email(getattr(customer, "email", None))
+        return _normalize_email(_stripe_value(customer, "email"))
     except Exception as e:
         logger.debug(f"Failed to retrieve customer email for {customer_id}: {e}")
         return None
 
 
-def _resolve_checkout_email(data_obj: Dict[str, Any]) -> Optional[str]:
-    customer_details = data_obj.get("customer_details") or {}
-    metadata = _get_metadata(data_obj)
+def _resolve_checkout_email(data_obj: Any) -> Optional[str]:
+    customer_details = _stripe_value(data_obj, "customer_details", {}) or {}
+    metadata = _stripe_value(data_obj, "metadata", {}) or {}
 
     return (
-        _normalize_email(customer_details.get("email"))
-        or _normalize_email(data_obj.get("customer_email"))
-        or _normalize_email(metadata.get("email"))
-        or _customer_email(data_obj.get("customer"))
+        _normalize_email(_stripe_value(metadata, "email"))
+        or _normalize_email(_stripe_value(customer_details, "email"))
+        or _normalize_email(_stripe_value(data_obj, "customer_email"))
+        or _customer_email(_stripe_value(data_obj, "customer"))
     )
+
+
+def _entitled_plan_for_status(status: Optional[str], price_id: Optional[str]) -> Optional[str]:
+    if status in ELIGIBLE_STATUSES:
+        return map_price_to_plan(price_id) if price_id else None
+    return "free"
+
+
+def _process_subscription_entitlement(
+    *,
+    event_id: Optional[str],
+    event_type: str,
+    subscription: Any,
+    email_hint: Optional[str] = None,
+    customer_id_hint: Optional[str] = None,
+    subscription_id_hint: Optional[str] = None,
+    deleted: bool = False,
+) -> JSONResponse:
+    subscription_id = _stripe_object_id(subscription) or subscription_id_hint
+    customer_value = _stripe_value(subscription, "customer")
+    customer_id = _stripe_object_id(customer_value) or customer_id_hint
+    status = "canceled" if deleted else str(_stripe_value(subscription, "status", "active"))
+    current_period_end = None if deleted else _stripe_value(subscription, "current_period_end")
+    price_id = None if deleted else _subscription_price_id(subscription)
+    email = (
+        email_hint or _subscription_metadata_email(subscription) or _customer_email(customer_value)
+    )
+    plan = (
+        "free"
+        if deleted or status in TERMINAL_STATUSES
+        else _entitled_plan_for_status(status, price_id)
+    )
+
+    if status in ELIGIBLE_STATUSES and not plan:
+        _monitor_webhook(
+            "stripe_webhook_entitlement_write_failed",
+            level="error",
+            event_id=event_id,
+            event_type=event_type,
+            object_id=subscription_id,
+            customer_id=customer_id,
+            subscription_id=subscription_id,
+            subscription_status=status,
+            price_id=price_id,
+            mapped_plan=plan,
+            email_hash=_email_hash(email),
+            db_write_succeeded=False,
+            failure_kind="unknown_price_id",
+            result="retryable_failure",
+        )
+        return _entitlement_failure_response("unknown_price_id")
+
+    sb_client = get_supabase_client()
+    if not sb_client:
+        _monitor_webhook(
+            "stripe_webhook_entitlement_write_failed",
+            level="error",
+            event_id=event_id,
+            event_type=event_type,
+            object_id=subscription_id,
+            customer_id=customer_id,
+            subscription_id=subscription_id,
+            subscription_status=status,
+            price_id=price_id,
+            mapped_plan=plan,
+            email_hash=_email_hash(email),
+            db_write_succeeded=False,
+            failure_kind="missing_supabase_client",
+            result="retryable_failure",
+        )
+        return _entitlement_failure_response()
+
+    try:
+        price_ok = True if deleted else _upsert_price_metadata(sb_client, price_id)
+        sub_ok = _upsert_subscription_record(
+            sb_client,
+            email=email,
+            customer_id=customer_id,
+            subscription_id=subscription_id,
+            status=status,
+            price_id=price_id,
+        )
+        user_ok = _write_user_plan(
+            sb_client,
+            customer_id=customer_id,
+            email=email,
+            plan_status=status,
+            current_period_end=current_period_end,
+            plan=plan,
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to write Stripe subscription entitlement data",
+            extra={
+                "event_id": event_id,
+                "event_type": event_type,
+                "customer_id": customer_id,
+                "subscription_id": subscription_id,
+                "subscription_status": status,
+                "price_id": price_id,
+                "mapped_plan": plan,
+                "email_hash": _email_hash(email),
+                "exception_type": type(e).__name__,
+                "error": str(e),
+            },
+        )
+        _monitor_webhook(
+            "stripe_webhook_entitlement_write_failed",
+            level="error",
+            event_id=event_id,
+            event_type=event_type,
+            object_id=subscription_id,
+            customer_id=customer_id,
+            subscription_id=subscription_id,
+            subscription_status=status,
+            price_id=price_id,
+            mapped_plan=plan,
+            email_hash=_email_hash(email),
+            db_write_succeeded=False,
+            failure_kind="db_write_exception",
+            exception_type=type(e).__name__,
+            result="retryable_failure",
+        )
+        return _entitlement_failure_response()
+
+    if not all([price_ok, sub_ok]):
+        _monitor_webhook(
+            "stripe_webhook_partial_db_write",
+            level="warning",
+            event_id=event_id,
+            event_type=event_type,
+            object_id=subscription_id,
+            customer_id=customer_id,
+            subscription_id=subscription_id,
+            subscription_status=status,
+            price_id=price_id,
+            mapped_plan=plan,
+            email_hash=_email_hash(email),
+            db_write_succeeded=False,
+            failure_kind="db_write_soft_failure",
+            result="processed_with_warnings",
+        )
+
+    if not user_ok:
+        _monitor_webhook(
+            "stripe_webhook_entitlement_write_failed",
+            level="error",
+            event_id=event_id,
+            event_type=event_type,
+            object_id=subscription_id,
+            customer_id=customer_id,
+            subscription_id=subscription_id,
+            subscription_status=status,
+            price_id=price_id,
+            mapped_plan=plan,
+            email_hash=_email_hash(email),
+            db_write_succeeded=False,
+            failure_kind="entitlement_write_failed",
+            result="retryable_failure",
+        )
+        return _entitlement_failure_response()
+
+    _monitor_webhook(
+        "stripe_webhook_processed",
+        level="info",
+        event_id=event_id,
+        event_type=event_type,
+        object_id=subscription_id,
+        customer_id=customer_id,
+        subscription_id=subscription_id,
+        subscription_status=status,
+        price_id=price_id,
+        mapped_plan=plan,
+        email_hash=_email_hash(email),
+        db_write_succeeded=True,
+        result="processed",
+    )
+    return JSONResponse({"ok": True})
 
 
 def _entitlement_failure_response(failure_kind: str = "entitlement_write_failed") -> JSONResponse:
@@ -236,11 +471,11 @@ def _upsert_price_metadata(sb_client: Any, price_id: Optional[str]) -> bool:
 
     data = {
         "stripe_price_id": price_id,
-        "product_id": price.get("product"),
-        "nickname": price.get("nickname"),
-        "unit_amount": price.get("unit_amount"),
-        "currency": price.get("currency"),
-        "billing_interval": (price.get("recurring") or {}).get("interval"),
+        "product_id": _stripe_value(price, "product"),
+        "nickname": _stripe_value(price, "nickname"),
+        "unit_amount": _stripe_value(price, "unit_amount"),
+        "currency": _stripe_value(price, "currency"),
+        "billing_interval": _stripe_value(_stripe_value(price, "recurring", {}), "interval"),
     }
 
     try:
@@ -421,577 +656,39 @@ async def stripe_webhook(request: Request):
         )
         return JSONResponse({"ok": False, "error": "webhook_internal_error"}, status_code=500)
 
-    etype = event.get("type")
-    event_id = event.get("id")
-    data_obj: Dict[str, Any] = (event.get("data") or {}).get("object") or {}
+    etype = _stripe_value(event, "type")
+    event_id = _stripe_value(event, "id")
+    data_obj: Any = _event_data_object(event)
 
     try:
         if etype == "checkout.session.completed":
-            sub_id = data_obj.get("subscription")
-            customer_id = data_obj.get("customer")
+            sub_value = _stripe_value(data_obj, "subscription")
+            sub_id = _stripe_object_id(sub_value)
             customer_email = _resolve_checkout_email(data_obj)
-
-            # In tests, these calls are patched
-            sub = (
-                stripe.Subscription.retrieve(sub_id)
-                if sub_id
-                else {"status": "active", "items": {"data": []}}
-            )
-            price_id = ((sub.get("items") or {}).get("data") or [{}])[0].get("price", {}).get("id")
-            status = sub.get("status", "active")
-            current_period_end = sub.get("current_period_end")
-
-            # Only treat certain statuses as eligible for a paid plan
-            eligible_for_plan = status in ["active", "trialing", "past_due"]
-
-            # Map price_id to plan - returns None for unknown IDs
-            plan = map_price_to_plan(price_id) if eligible_for_plan else None
-            if eligible_for_plan and not plan:
-                _monitor_webhook(
-                    "stripe_webhook_entitlement_write_failed",
-                    level="error",
-                    event_id=event_id,
-                    event_type=etype,
-                    customer_id=customer_id,
-                    subscription_id=sub_id,
-                    price_id=price_id,
-                    mapped_plan=plan,
-                    email_hash=_email_hash(customer_email),
-                    db_write_succeeded=False,
-                    failure_kind="unknown_price_id",
-                )
-                return _entitlement_failure_response("unknown_price_id")
-            # Always preserve the real Stripe status
-            plan_status = status
-
-            # Get Supabase client (lazy, may be None)
-            sb_client = get_supabase_client()
-            db_write_succeeded = sb_client is not None
-
-            if sb_client:
-                try:
-                    # Keep admin stats stable by persisting both subscription + price metadata.
-                    price_ok = _upsert_price_metadata(sb_client, price_id)
-                    sub_ok = _upsert_subscription_record(
-                        sb_client,
-                        email=customer_email,
-                        customer_id=customer_id,
-                        subscription_id=sub_id,
-                        status=status,
-                        price_id=price_id,
-                    )
-
-                    # Users upsert LAST (tests inspect last upsert call).
-                    user_ok = _write_user_plan(
-                        sb_client,
-                        customer_id=customer_id,
-                        email=customer_email,
-                        plan_status=plan_status,
-                        current_period_end=current_period_end,
-                        plan=plan,
-                    )
-                    optional_ok = all([price_ok, sub_ok])
-                    db_write_succeeded = user_ok
-                    if not optional_ok:
-                        _monitor_webhook(
-                            "stripe_webhook_partial_db_write",
-                            level="warning",
-                            event_id=event_id,
-                            event_type=etype,
-                            customer_id=customer_id,
-                            subscription_id=sub_id,
-                            price_id=price_id,
-                            mapped_plan=plan,
-                            email_hash=_email_hash(customer_email),
-                            db_write_succeeded=False,
-                            failure_kind="db_write_soft_failure",
-                        )
-                    if not user_ok:
-                        _monitor_webhook(
-                            "stripe_webhook_entitlement_write_failed",
-                            level="error",
-                            event_id=event_id,
-                            event_type=etype,
-                            customer_id=customer_id,
-                            subscription_id=sub_id,
-                            price_id=price_id,
-                            mapped_plan=plan,
-                            email_hash=_email_hash(customer_email),
-                            db_write_succeeded=False,
-                            failure_kind="entitlement_write_failed",
-                        )
-                        return _entitlement_failure_response()
-                except Exception as e:
-                    logger.warning(
-                        "Failed to write checkout.session.completed entitlement data",
-                        extra={
-                            "event_id": event_id,
-                            "customer_id": customer_id,
-                            "subscription_id": sub_id,
-                            "price_id": price_id,
-                            "mapped_plan": plan,
-                            "email_hash": _email_hash(customer_email),
-                            "error": str(e),
-                        },
-                    )
-                    db_write_succeeded = False
-                    _monitor_webhook(
-                        "stripe_webhook_entitlement_write_failed",
-                        level="error",
-                        event_id=event_id,
-                        event_type=etype,
-                        customer_id=customer_id,
-                        subscription_id=sub_id,
-                        price_id=price_id,
-                        mapped_plan=plan,
-                        email_hash=_email_hash(customer_email),
-                        db_write_succeeded=False,
-                        failure_kind="db_write_exception",
-                    )
-                    return _entitlement_failure_response()
-
-            if not sb_client:
-                _monitor_webhook(
-                    "stripe_webhook_entitlement_write_failed",
-                    level="error",
-                    event_id=event_id,
-                    event_type=etype,
-                    customer_id=customer_id,
-                    subscription_id=sub_id,
-                    price_id=price_id,
-                    mapped_plan=plan,
-                    email_hash=_email_hash(customer_email),
-                    db_write_succeeded=False,
-                    failure_kind="missing_supabase_client",
-                )
-                return _entitlement_failure_response()
-
-            _monitor_webhook(
-                "stripe_webhook_processed",
-                level="info",
+            sub = stripe.Subscription.retrieve(sub_id) if sub_id else sub_value
+            return _process_subscription_entitlement(
                 event_id=event_id,
                 event_type=etype,
-                customer_id=customer_id,
-                subscription_id=sub_id,
-                price_id=price_id,
-                mapped_plan=plan,
-                email_hash=_email_hash(customer_email),
-                db_write_succeeded=db_write_succeeded,
+                subscription=sub,
+                email_hint=customer_email,
+                customer_id_hint=_stripe_object_id(_stripe_value(data_obj, "customer")),
+                subscription_id_hint=sub_id,
             )
 
-            return JSONResponse({"ok": True})
-
-        if etype == "customer.subscription.updated":
-            customer_id = data_obj.get("customer")
-            price_id = (
-                ((data_obj.get("items") or {}).get("data") or [{}])[0].get("price", {}).get("id")
-            )
-            status = data_obj.get("status", "active")
-            current_period_end = data_obj.get("current_period_end")
-
-            # Retrieve customer email - handle potential failures gracefully
-            email = _customer_email(customer_id)
-
-            # Only treat certain statuses as eligible for a paid plan
-            eligible_for_plan = status in ["active", "trialing", "past_due"]
-
-            # Map price_id to plan - returns None for unknown IDs
-            plan = map_price_to_plan(price_id) if eligible_for_plan else None
-            if eligible_for_plan and not plan:
-                _monitor_webhook(
-                    "stripe_webhook_entitlement_write_failed",
-                    level="error",
-                    event_id=event_id,
-                    event_type=etype,
-                    customer_id=customer_id,
-                    subscription_id=data_obj.get("id"),
-                    price_id=price_id,
-                    mapped_plan=plan,
-                    email_hash=_email_hash(email),
-                    db_write_succeeded=False,
-                    failure_kind="unknown_price_id",
-                )
-                return _entitlement_failure_response("unknown_price_id")
-            # Always preserve the real Stripe status
-            plan_status = status
-
-            # Get Supabase client (lazy, may be None)
-            sb_client = get_supabase_client()
-            db_write_succeeded = sb_client is not None
-
-            if sb_client:
-                try:
-                    price_ok = _upsert_price_metadata(sb_client, price_id)
-                    sub_ok = _upsert_subscription_record(
-                        sb_client,
-                        email=email,
-                        customer_id=customer_id,
-                        subscription_id=data_obj.get("id"),
-                        status=status,
-                        price_id=price_id,
-                    )
-
-                    user_ok = _write_user_plan(
-                        sb_client,
-                        customer_id=customer_id,
-                        email=email,
-                        plan_status=plan_status,
-                        current_period_end=current_period_end,
-                        plan=plan,
-                    )
-                    optional_ok = all([price_ok, sub_ok])
-                    db_write_succeeded = user_ok
-                    if not optional_ok:
-                        _monitor_webhook(
-                            "stripe_webhook_partial_db_write",
-                            level="warning",
-                            event_id=event_id,
-                            event_type=etype,
-                            customer_id=customer_id,
-                            subscription_id=data_obj.get("id"),
-                            price_id=price_id,
-                            mapped_plan=plan,
-                            email_hash=_email_hash(email),
-                            db_write_succeeded=False,
-                            failure_kind="db_write_soft_failure",
-                        )
-                    if not user_ok:
-                        _monitor_webhook(
-                            "stripe_webhook_entitlement_write_failed",
-                            level="error",
-                            event_id=event_id,
-                            event_type=etype,
-                            customer_id=customer_id,
-                            subscription_id=data_obj.get("id"),
-                            price_id=price_id,
-                            mapped_plan=plan,
-                            email_hash=_email_hash(email),
-                            db_write_succeeded=False,
-                            failure_kind="entitlement_write_failed",
-                        )
-                        return _entitlement_failure_response()
-                except Exception as e:
-                    logger.warning(
-                        "Failed to write subscription.updated entitlement data",
-                        extra={
-                            "event_id": event_id,
-                            "customer_id": customer_id,
-                            "subscription_id": data_obj.get("id"),
-                            "price_id": price_id,
-                            "mapped_plan": plan,
-                            "email_hash": _email_hash(email),
-                            "error": str(e),
-                        },
-                    )
-                    db_write_succeeded = False
-                    _monitor_webhook(
-                        "stripe_webhook_entitlement_write_failed",
-                        level="error",
-                        event_id=event_id,
-                        event_type=etype,
-                        customer_id=customer_id,
-                        subscription_id=data_obj.get("id"),
-                        price_id=price_id,
-                        mapped_plan=plan,
-                        email_hash=_email_hash(email),
-                        db_write_succeeded=False,
-                        failure_kind="db_write_exception",
-                    )
-                    return _entitlement_failure_response()
-
-            if not sb_client:
-                _monitor_webhook(
-                    "stripe_webhook_entitlement_write_failed",
-                    level="error",
-                    event_id=event_id,
-                    event_type=etype,
-                    customer_id=customer_id,
-                    subscription_id=data_obj.get("id"),
-                    price_id=price_id,
-                    mapped_plan=plan,
-                    email_hash=_email_hash(email),
-                    db_write_succeeded=False,
-                    failure_kind="missing_supabase_client",
-                )
-                return _entitlement_failure_response()
-
-            _monitor_webhook(
-                "stripe_webhook_processed",
-                level="info",
+        if etype in {"customer.subscription.created", "customer.subscription.updated"}:
+            return _process_subscription_entitlement(
                 event_id=event_id,
                 event_type=etype,
-                customer_id=customer_id,
-                subscription_id=data_obj.get("id"),
-                price_id=price_id,
-                mapped_plan=plan,
-                email_hash=_email_hash(email),
-                db_write_succeeded=db_write_succeeded,
+                subscription=data_obj,
             )
-
-            return JSONResponse({"ok": True})
-
-        if etype == "customer.subscription.created":
-            customer_id = data_obj.get("customer")
-            price_id = (
-                ((data_obj.get("items") or {}).get("data") or [{}])[0].get("price", {}).get("id")
-            )
-            status = data_obj.get("status", "active")
-            current_period_end = data_obj.get("current_period_end")
-
-            # Retrieve customer email - handle potential failures gracefully
-            email = _customer_email(customer_id)
-
-            # Map price_id to plan - returns None for unknown IDs
-            plan = map_price_to_plan(price_id)
-            eligible_for_plan = status in ["active", "trialing", "past_due"]
-            if eligible_for_plan and not plan:
-                _monitor_webhook(
-                    "stripe_webhook_entitlement_write_failed",
-                    level="error",
-                    event_id=event_id,
-                    event_type=etype,
-                    customer_id=customer_id,
-                    subscription_id=data_obj.get("id"),
-                    price_id=price_id,
-                    mapped_plan=plan,
-                    email_hash=_email_hash(email),
-                    db_write_succeeded=False,
-                    failure_kind="unknown_price_id",
-                )
-                return _entitlement_failure_response("unknown_price_id")
-            plan_status = (
-                status if status in ["active", "past_due", "canceled", "trialing"] else "active"
-            )
-
-            # Get Supabase client (lazy, may be None)
-            sb_client = get_supabase_client()
-            db_write_succeeded = sb_client is not None
-
-            if sb_client:
-                try:
-                    price_ok = _upsert_price_metadata(sb_client, price_id)
-                    sub_ok = _upsert_subscription_record(
-                        sb_client,
-                        email=email,
-                        customer_id=customer_id,
-                        subscription_id=data_obj.get("id"),
-                        status=status,
-                        price_id=price_id,
-                    )
-
-                    user_ok = _write_user_plan(
-                        sb_client,
-                        customer_id=customer_id,
-                        email=email,
-                        plan_status=plan_status,
-                        current_period_end=current_period_end,
-                        plan=plan,
-                    )
-                    optional_ok = all([price_ok, sub_ok])
-                    db_write_succeeded = user_ok
-                    if not optional_ok:
-                        _monitor_webhook(
-                            "stripe_webhook_partial_db_write",
-                            level="warning",
-                            event_id=event_id,
-                            event_type=etype,
-                            customer_id=customer_id,
-                            subscription_id=data_obj.get("id"),
-                            price_id=price_id,
-                            mapped_plan=plan,
-                            email_hash=_email_hash(email),
-                            db_write_succeeded=False,
-                            failure_kind="db_write_soft_failure",
-                        )
-                    if not user_ok:
-                        _monitor_webhook(
-                            "stripe_webhook_entitlement_write_failed",
-                            level="error",
-                            event_id=event_id,
-                            event_type=etype,
-                            customer_id=customer_id,
-                            subscription_id=data_obj.get("id"),
-                            price_id=price_id,
-                            mapped_plan=plan,
-                            email_hash=_email_hash(email),
-                            db_write_succeeded=False,
-                            failure_kind="entitlement_write_failed",
-                        )
-                        return _entitlement_failure_response()
-                except Exception as e:
-                    logger.warning(
-                        "Failed to write subscription.created entitlement data",
-                        extra={
-                            "event_id": event_id,
-                            "customer_id": customer_id,
-                            "subscription_id": data_obj.get("id"),
-                            "price_id": price_id,
-                            "mapped_plan": plan,
-                            "email_hash": _email_hash(email),
-                            "error": str(e),
-                        },
-                    )
-                    db_write_succeeded = False
-                    _monitor_webhook(
-                        "stripe_webhook_entitlement_write_failed",
-                        level="error",
-                        event_id=event_id,
-                        event_type=etype,
-                        customer_id=customer_id,
-                        subscription_id=data_obj.get("id"),
-                        price_id=price_id,
-                        mapped_plan=plan,
-                        email_hash=_email_hash(email),
-                        db_write_succeeded=False,
-                        failure_kind="db_write_exception",
-                    )
-                    return _entitlement_failure_response()
-
-            if not sb_client:
-                _monitor_webhook(
-                    "stripe_webhook_entitlement_write_failed",
-                    level="error",
-                    event_id=event_id,
-                    event_type=etype,
-                    customer_id=customer_id,
-                    subscription_id=data_obj.get("id"),
-                    price_id=price_id,
-                    mapped_plan=plan,
-                    email_hash=_email_hash(email),
-                    db_write_succeeded=False,
-                    failure_kind="missing_supabase_client",
-                )
-                return _entitlement_failure_response()
-
-            _monitor_webhook(
-                "stripe_webhook_processed",
-                level="info",
-                event_id=event_id,
-                event_type=etype,
-                customer_id=customer_id,
-                subscription_id=data_obj.get("id"),
-                price_id=price_id,
-                mapped_plan=plan,
-                email_hash=_email_hash(email),
-                db_write_succeeded=db_write_succeeded,
-            )
-
-            return JSONResponse({"ok": True})
 
         if etype == "customer.subscription.deleted":
-            customer_id = data_obj.get("customer")
-
-            # Retrieve customer email - handle potential failures gracefully
-            email = _customer_email(customer_id)
-
-            # Get Supabase client (lazy, may be None)
-            sb_client = get_supabase_client()
-            db_write_succeeded = sb_client is not None
-
-            if sb_client:
-                try:
-                    # Mark subscription as canceled if we can identify it.
-                    sub_ok = _upsert_subscription_record(
-                        sb_client,
-                        email=email,
-                        customer_id=customer_id,
-                        subscription_id=data_obj.get("id"),
-                        status="canceled",
-                        price_id=None,
-                    )
-
-                    # Downgrade to free plan when subscription is deleted.
-                    user_ok = _write_user_plan(
-                        sb_client,
-                        customer_id=customer_id,
-                        email=email,
-                        plan_status="canceled",
-                        current_period_end=None,
-                        plan="free",
-                    )
-                    db_write_succeeded = user_ok
-                    if not sub_ok:
-                        _monitor_webhook(
-                            "stripe_webhook_partial_db_write",
-                            level="warning",
-                            event_id=event_id,
-                            event_type=etype,
-                            customer_id=customer_id,
-                            subscription_id=data_obj.get("id"),
-                            mapped_plan="free",
-                            email_hash=_email_hash(email),
-                            db_write_succeeded=False,
-                            failure_kind="db_write_soft_failure",
-                        )
-                    if not user_ok:
-                        _monitor_webhook(
-                            "stripe_webhook_entitlement_write_failed",
-                            level="error",
-                            event_id=event_id,
-                            event_type=etype,
-                            customer_id=customer_id,
-                            subscription_id=data_obj.get("id"),
-                            mapped_plan="free",
-                            email_hash=_email_hash(email),
-                            db_write_succeeded=False,
-                            failure_kind="entitlement_write_failed",
-                        )
-                        return _entitlement_failure_response()
-                except Exception as e:
-                    logger.warning(
-                        "Failed to write subscription.deleted entitlement data",
-                        extra={
-                            "event_id": event_id,
-                            "customer_id": customer_id,
-                            "subscription_id": data_obj.get("id"),
-                            "mapped_plan": "free",
-                            "email_hash": _email_hash(email),
-                            "error": str(e),
-                        },
-                    )
-                    db_write_succeeded = False
-                    _monitor_webhook(
-                        "stripe_webhook_entitlement_write_failed",
-                        level="error",
-                        event_id=event_id,
-                        event_type=etype,
-                        customer_id=customer_id,
-                        subscription_id=data_obj.get("id"),
-                        mapped_plan="free",
-                        email_hash=_email_hash(email),
-                        db_write_succeeded=False,
-                        failure_kind="db_write_exception",
-                    )
-                    return _entitlement_failure_response()
-
-            if not sb_client:
-                _monitor_webhook(
-                    "stripe_webhook_entitlement_write_failed",
-                    level="error",
-                    event_id=event_id,
-                    event_type=etype,
-                    customer_id=customer_id,
-                    subscription_id=data_obj.get("id"),
-                    mapped_plan="free",
-                    email_hash=_email_hash(email),
-                    db_write_succeeded=False,
-                    failure_kind="missing_supabase_client",
-                )
-                return _entitlement_failure_response()
-
-            _monitor_webhook(
-                "stripe_webhook_processed",
-                level="info",
+            return _process_subscription_entitlement(
                 event_id=event_id,
                 event_type=etype,
-                customer_id=customer_id,
-                subscription_id=data_obj.get("id"),
-                mapped_plan="free",
-                email_hash=_email_hash(email),
-                db_write_succeeded=db_write_succeeded,
+                subscription=data_obj,
+                deleted=True,
             )
-
-            return JSONResponse({"ok": True})
 
         # Unhandled but valid
         _monitor_webhook(
@@ -999,9 +696,11 @@ async def stripe_webhook(request: Request):
             level="info",
             event_id=event_id,
             event_type=etype,
-            customer_id=data_obj.get("customer"),
-            subscription_id=data_obj.get("id"),
+            object_id=_stripe_object_id(data_obj),
+            customer_id=_stripe_object_id(_stripe_value(data_obj, "customer")),
+            subscription_id=_stripe_object_id(data_obj),
             db_write_succeeded=None,
+            result="ignored",
         )
         return JSONResponse({"ok": True, "ignored": etype})
     except Exception as e:
@@ -1010,9 +709,11 @@ async def stripe_webhook(request: Request):
             stripe_webhook={
                 "event_id": event_id,
                 "event_type": etype,
-                "customer_id": data_obj.get("customer"),
-                "subscription_id": data_obj.get("id"),
+                "object_id": _stripe_object_id(data_obj),
+                "customer_id": _stripe_object_id(_stripe_value(data_obj, "customer")),
+                "subscription_id": _stripe_object_id(data_obj),
                 "failure_kind": "unexpected_processing_exception",
+                "exception_type": type(e).__name__,
             },
         )
         _monitor_webhook(
@@ -1020,9 +721,12 @@ async def stripe_webhook(request: Request):
             level="error",
             event_id=event_id,
             event_type=etype,
-            customer_id=data_obj.get("customer"),
-            subscription_id=data_obj.get("id"),
+            object_id=_stripe_object_id(data_obj),
+            customer_id=_stripe_object_id(_stripe_value(data_obj, "customer")),
+            subscription_id=_stripe_object_id(data_obj),
             db_write_succeeded=False,
             failure_kind="unexpected_processing_exception",
+            exception_type=type(e).__name__,
+            result="retryable_failure",
         )
         return JSONResponse({"ok": False, "error": "webhook_processing_failed"}, status_code=500)

--- a/backend/scripts/reconcile_stripe_subscription.py
+++ b/backend/scripts/reconcile_stripe_subscription.py
@@ -9,15 +9,18 @@ from typing import Any
 import stripe
 
 from backend.routes.stripe_webhook import (
+    ELIGIBLE_STATUSES,
+    TERMINAL_STATUSES,
     _normalize_email,
+    _stripe_list_data,
+    _stripe_object_id,
+    _stripe_value,
     _upsert_price_metadata,
     _upsert_subscription_record,
     _write_user_plan,
     map_price_to_plan,
 )
 from backend.utils.supabase_client import get_supabase
-
-ELIGIBLE_STATUSES = {"active", "trialing", "past_due"}
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -34,11 +37,12 @@ def _as_dict(value: Any) -> dict[str, Any]:
 
 def _customer_email(customer: Any) -> str | None:
     data = _as_dict(customer)
-    return _normalize_email(data.get("email") or getattr(customer, "email", None))
+    return _normalize_email(_stripe_value(data, "email") or _stripe_value(customer, "email"))
 
 
-def _subscription_price_id(subscription: dict[str, Any]) -> str | None:
-    return (((subscription.get("items") or {}).get("data") or [{}])[0].get("price") or {}).get("id")
+def _subscription_price_id(subscription: Any) -> str | None:
+    first_item = (_stripe_list_data(_stripe_value(subscription, "items", {})) or [{}])[0]
+    return _stripe_object_id(_stripe_value(first_item, "price"))
 
 
 def _retrieve_checkout_session(
@@ -50,16 +54,18 @@ def _retrieve_checkout_session(
             expand=["subscription", "customer"],
         )
     )
-    subscription_value = session.get("subscription")
+    subscription_value = _stripe_value(session, "subscription")
     subscription = (
         subscription_value
         if isinstance(subscription_value, dict)
         else _as_dict(stripe.Subscription.retrieve(subscription_value))
     )
-    customer = session.get("customer")
-    email = _normalize_email((session.get("customer_details") or {}).get("email"))
-    email = email or _normalize_email(session.get("customer_email"))
-    email = email or _normalize_email((session.get("metadata") or {}).get("email"))
+    customer = _stripe_value(session, "customer")
+    email = _normalize_email(_stripe_value(_stripe_value(session, "metadata", {}), "email"))
+    email = email or _normalize_email(
+        _stripe_value(_stripe_value(session, "customer_details", {}), "email")
+    )
+    email = email or _normalize_email(_stripe_value(session, "customer_email"))
     email = email or _customer_email(customer)
     return session, subscription, email
 
@@ -75,7 +81,7 @@ def _find_customer_by_email(email: str) -> dict[str, Any]:
 def _find_subscription_for_customer(customer_id: str) -> dict[str, Any]:
     subscriptions = stripe.Subscription.list(customer=customer_id, status="all", limit=10)
     items = [_as_dict(item) for item in (getattr(subscriptions, "data", None) or [])]
-    eligible = [item for item in items if item.get("status") in ELIGIBLE_STATUSES]
+    eligible = [item for item in items if _stripe_value(item, "status") in ELIGIBLE_STATUSES]
     if eligible:
         return eligible[0]
     if items:
@@ -88,8 +94,8 @@ def _resolve(
 ) -> tuple[dict[str, Any] | None, dict[str, Any], str | None, str | None]:
     if args.checkout_session_id:
         session, subscription, email = _retrieve_checkout_session(args.checkout_session_id)
-        customer = session.get("customer")
-        customer_id = customer.get("id") if isinstance(customer, dict) else customer
+        customer = _stripe_value(session, "customer")
+        customer_id = _stripe_object_id(customer)
         return session, subscription, customer_id, email
 
     if args.customer_id:
@@ -102,7 +108,7 @@ def _resolve(
         if not email:
             raise RuntimeError("A valid email is required")
         customer = _find_customer_by_email(email)
-        customer_id = customer.get("id")
+        customer_id = _stripe_object_id(customer)
         subscription = _find_subscription_for_customer(customer_id)
         return None, subscription, customer_id, email
 
@@ -129,11 +135,13 @@ def main() -> int:
     stripe.api_key = secret
 
     _session, subscription, customer_id, email = _resolve(args)
-    subscription_id = subscription.get("id")
-    status = subscription.get("status")
-    current_period_end = subscription.get("current_period_end")
+    subscription_id = _stripe_object_id(subscription)
+    status = _stripe_value(subscription, "status")
+    current_period_end = _stripe_value(subscription, "current_period_end")
     price_id = _subscription_price_id(subscription)
-    plan = map_price_to_plan(price_id) if status in ELIGIBLE_STATUSES else None
+    plan = map_price_to_plan(price_id) if status in ELIGIBLE_STATUSES else "free"
+    if status in TERMINAL_STATUSES:
+        plan = "free"
 
     result = {
         "dry_run": args.dry_run,

--- a/backend/tests/test_reconcile_stripe_subscription.py
+++ b/backend/tests/test_reconcile_stripe_subscription.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+
+from backend.scripts import reconcile_stripe_subscription as reconcile
+
+
+class AttrOnlyObject:
+    def __init__(self, **values):
+        for key, value in values.items():
+            setattr(self, key, value)
+
+
+def test_reconcile_canceled_subscription_writes_free(monkeypatch):
+    writes: list[dict[str, object]] = []
+
+    subscription = AttrOnlyObject(
+        id="sub_canceled",
+        customer="cus_canceled",
+        status="canceled",
+        current_period_end=1234567890,
+        items=AttrOnlyObject(data=[AttrOnlyObject(price=AttrOnlyObject(id="price_pro"))]),
+    )
+
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "test-secret-key")
+    monkeypatch.setattr(
+        reconcile,
+        "_resolve",
+        lambda args: (None, subscription, "cus_canceled", "Canceled@Example.COM"),
+    )
+    monkeypatch.setattr(reconcile, "get_supabase", lambda required=True: object())
+    monkeypatch.setattr(reconcile, "_upsert_price_metadata", lambda *args, **kwargs: True)
+    monkeypatch.setattr(reconcile, "_upsert_subscription_record", lambda *args, **kwargs: True)
+
+    def _write_user_plan(*args, **kwargs):
+        writes.append(kwargs)
+        return True
+
+    monkeypatch.setattr(reconcile, "_write_user_plan", _write_user_plan)
+    monkeypatch.setattr(
+        reconcile,
+        "argparse",
+        argparse,
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["reconcile_stripe_subscription.py", "--customer-id", "cus_canceled"],
+    )
+
+    assert reconcile.main() == 0
+    assert writes == [
+        {
+            "customer_id": "cus_canceled",
+            "email": "Canceled@Example.COM",
+            "plan_status": "canceled",
+            "current_period_end": 1234567890,
+            "plan": "free",
+        }
+    ]

--- a/backend/tests/test_stripe_webhook.py
+++ b/backend/tests/test_stripe_webhook.py
@@ -10,6 +10,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 
+class AttrOnlyObject:
+    def __init__(self, **values):
+        for key, value in values.items():
+            setattr(self, key, value)
+
+
 @pytest.fixture
 def client():
     """Create a test client"""
@@ -82,7 +88,7 @@ def _post_checkout_completed(client, mock_stripe, *, email_fields=None, price_id
     }
 
     os.environ["STRIPE_PRICE_PRO"] = price_id
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
     return client.post(
         "/stripe/webhook",
         data=json.dumps(mock_event),
@@ -149,7 +155,7 @@ def test_checkout_completed_event(mock_supabase, mock_stripe, client):
     mock_supabase.table.return_value.upsert.return_value.execute.return_value = Mock(data=[])
 
     # Set webhook secret
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     response = client.post(
         "/stripe/webhook",
@@ -181,7 +187,7 @@ def test_subscription_updated_event(mock_stripe, mock_supabase, client):
     mock_stripe.Webhook.construct_event.return_value = mock_event
     mock_stripe.Customer.retrieve.return_value = {"email": "test@example.com"}
 
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     response = client.post(
         "/stripe/webhook",
@@ -257,7 +263,7 @@ def test_unknown_price_id_preserves_plan(mock_stripe, mock_supabase, client):
     # Mock Supabase upsert
     mock_supabase.table.return_value.upsert.return_value.execute.return_value = Mock(data=[])
 
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     response = client.post(
         "/stripe/webhook", data=json.dumps(mock_event), headers={"Stripe-Signature": "test_sig"}
@@ -379,7 +385,7 @@ def test_subscription_deleted_updates_existing_user_without_replacing_id(
     }
     mock_stripe.Webhook.construct_event.return_value = mock_event
     mock_stripe.Customer.retrieve.return_value = {"email": "downgrade@example.com"}
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     response = client.post(
         "/stripe/webhook",
@@ -422,7 +428,7 @@ def test_graceful_handling_no_supabase(mock_stripe, client):
         "current_period_end": 1234567890,
     }
 
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     response = client.post(
         "/stripe/webhook", data=json.dumps(mock_event), headers={"Stripe-Signature": "test_sig"}
@@ -460,7 +466,7 @@ def test_subscription_updated_email_retrieval_failure(mock_stripe, mock_supabase
     # Mock Supabase upsert
     mock_supabase.table.return_value.upsert.return_value.execute.return_value = Mock(data=[])
 
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     response = client.post(
         "/stripe/webhook", data=json.dumps(mock_event), headers={"Stripe-Signature": "test_sig"}
@@ -496,7 +502,7 @@ def test_subscription_created_pro(mock_stripe, mock_supabase, client):
     # Mock Supabase upsert
     mock_supabase.table.return_value.upsert.return_value.execute.return_value = Mock(data=[])
 
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     response = client.post(
         "/stripe/webhook", data=json.dumps(mock_event), headers={"Stripe-Signature": "test_sig"}
@@ -539,7 +545,7 @@ def test_subscription_created_investor(mock_stripe, mock_supabase, client):
     # Mock Supabase upsert
     mock_supabase.table.return_value.upsert.return_value.execute.return_value = Mock(data=[])
 
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     response = client.post(
         "/stripe/webhook", data=json.dumps(mock_event), headers={"Stripe-Signature": "test_sig"}
@@ -577,7 +583,7 @@ def test_subscription_deleted_downgrades_to_free(mock_stripe, mock_supabase, cli
     # Mock Supabase upsert
     mock_supabase.table.return_value.upsert.return_value.execute.return_value = Mock(data=[])
 
-    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     response = client.post(
         "/stripe/webhook", data=json.dumps(mock_event), headers={"Stripe-Signature": "test_sig"}
@@ -681,3 +687,197 @@ def test_checkout_completed_with_investor_price(mock_stripe, mock_supabase, clie
     upsert_data = mock_supabase.table.return_value.upsert.call_args[0][0]
     assert upsert_data["plan"] == "investor"
     assert upsert_data["plan_status"] == "active"
+
+
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_checkout_completed_accepts_stripe_attr_objects_without_get(
+    mock_stripe, mock_supabase, client
+):
+    users_table, _subscriptions_table, _prices_table = _mock_supabase_tables(
+        mock_supabase,
+        user_update_rows=[{"id": "existing-user-id", "email": "attr@example.com"}],
+    )
+    assert not hasattr(AttrOnlyObject(), "get")
+
+    os.environ["STRIPE_PRICE_PRO"] = "price_attr_pro"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
+    mock_stripe.Webhook.construct_event.return_value = AttrOnlyObject(
+        id="evt_attr_checkout",
+        type="checkout.session.completed",
+        data=AttrOnlyObject(
+            object=AttrOnlyObject(
+                id="cs_attr",
+                customer=AttrOnlyObject(id="cus_attr", email="customer@example.com"),
+                subscription="sub_attr",
+                metadata=AttrOnlyObject(email=" Attr@Example.COM "),
+            )
+        ),
+    )
+    mock_stripe.Subscription.retrieve.return_value = AttrOnlyObject(
+        id="sub_attr",
+        customer="cus_attr",
+        status="trialing",
+        current_period_end=1234567890,
+        items=AttrOnlyObject(data=[AttrOnlyObject(price=AttrOnlyObject(id="price_attr_pro"))]),
+    )
+    mock_stripe.Price.retrieve.return_value = AttrOnlyObject(
+        id="price_attr_pro",
+        product="prod_attr",
+        recurring=AttrOnlyObject(interval="month"),
+    )
+
+    response = client.post(
+        "/stripe/webhook",
+        data=b"{}",
+        headers={"Stripe-Signature": "test_sig"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    update_payload = users_table.update.call_args.args[0]
+    assert update_payload["plan"] == "pro"
+    assert update_payload["plan_status"] == "trialing"
+    users_table.update.return_value.eq.assert_called_with("email", "attr@example.com")
+
+
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_subscription_created_accepts_attr_items_customer_string_and_no_metadata(
+    mock_stripe, mock_supabase, client
+):
+    users_table, _subscriptions_table, _prices_table = _mock_supabase_tables(
+        mock_supabase,
+        user_update_rows=[{"id": "existing-user-id", "email": "created@example.com"}],
+    )
+    os.environ["STRIPE_PRICE_PRO"] = "price_attr_created"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
+    mock_stripe.Webhook.construct_event.return_value = AttrOnlyObject(
+        id="evt_attr_created",
+        type="customer.subscription.created",
+        data=AttrOnlyObject(
+            object=AttrOnlyObject(
+                id="sub_attr_created",
+                customer="cus_attr_created",
+                status="active",
+                current_period_end=1234567890,
+                items=AttrOnlyObject(
+                    data=[AttrOnlyObject(price=AttrOnlyObject(id="price_attr_created"))]
+                ),
+            )
+        ),
+    )
+    mock_stripe.Customer.retrieve.return_value = AttrOnlyObject(email="created@example.com")
+
+    response = client.post(
+        "/stripe/webhook",
+        data=b"{}",
+        headers={"Stripe-Signature": "test_sig"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    update_payload = users_table.update.call_args.args[0]
+    assert update_payload["plan"] == "pro"
+    assert update_payload["stripe_customer_id"] == "cus_attr_created"
+
+
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_subscription_deleted_attr_object_maps_to_free(mock_stripe, mock_supabase, client):
+    users_table, _subscriptions_table, _prices_table = _mock_supabase_tables(
+        mock_supabase,
+        user_update_rows=[{"id": "existing-user-id", "email": "deleted@example.com"}],
+    )
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
+    mock_stripe.Webhook.construct_event.return_value = AttrOnlyObject(
+        id="evt_attr_deleted",
+        type="customer.subscription.deleted",
+        data=AttrOnlyObject(
+            object=AttrOnlyObject(
+                id="sub_attr_deleted",
+                customer=AttrOnlyObject(id="cus_attr_deleted", email="deleted@example.com"),
+                status="canceled",
+            )
+        ),
+    )
+
+    response = client.post(
+        "/stripe/webhook",
+        data=b"{}",
+        headers={"Stripe-Signature": "test_sig"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    update_payload = users_table.update.call_args.args[0]
+    assert update_payload["plan"] == "free"
+    assert update_payload["plan_status"] == "canceled"
+
+
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_subscription_attr_unknown_price_is_retryable_without_grant(
+    mock_stripe, mock_supabase, client
+):
+    for key in ["STRIPE_PRICE_PRO", "NEXT_PUBLIC_STRIPE_PRICE_PRO", "STRIPE_PRICE_INVESTOR"]:
+        os.environ.pop(key, None)
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
+    mock_stripe.Webhook.construct_event.return_value = AttrOnlyObject(
+        id="evt_attr_unknown",
+        type="customer.subscription.updated",
+        data=AttrOnlyObject(
+            object=AttrOnlyObject(
+                id="sub_attr_unknown",
+                customer="cus_attr_unknown",
+                status="active",
+                items=AttrOnlyObject(
+                    data=[AttrOnlyObject(price=AttrOnlyObject(id="price_attr_unknown"))]
+                ),
+            )
+        ),
+    )
+    mock_stripe.Price.retrieve.side_effect = Exception("unknown price")
+
+    response = client.post(
+        "/stripe/webhook",
+        data=b"{}",
+        headers={"Stripe-Signature": "test_sig"},
+    )
+
+    assert response.status_code == 500
+    assert response.json() == {"ok": False, "error": "unknown_price_id"}
+    assert not mock_supabase.table.called
+
+
+@patch("backend.routes.stripe_webhook.supabase")
+@patch("backend.routes.stripe_webhook.stripe")
+def test_subscription_attr_retry_is_idempotent(mock_stripe, mock_supabase, client):
+    users_table, _subscriptions_table, _prices_table = _mock_supabase_tables(
+        mock_supabase,
+        user_update_rows=[{"id": "existing-user-id", "email": "retry@example.com"}],
+    )
+    os.environ["STRIPE_PRICE_PRO"] = "price_attr_retry"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
+    mock_stripe.Webhook.construct_event.return_value = AttrOnlyObject(
+        id="evt_attr_retry",
+        type="customer.subscription.updated",
+        data=AttrOnlyObject(
+            object=AttrOnlyObject(
+                id="sub_attr_retry",
+                customer="cus_attr_retry",
+                status="active",
+                items=AttrOnlyObject(
+                    data=[AttrOnlyObject(price=AttrOnlyObject(id="price_attr_retry"))]
+                ),
+            )
+        ),
+    )
+    mock_stripe.Customer.retrieve.return_value = AttrOnlyObject(email="retry@example.com")
+
+    first = client.post("/stripe/webhook", data=b"{}", headers={"Stripe-Signature": "sig"})
+    second = client.post("/stripe/webhook", data=b"{}", headers={"Stripe-Signature": "sig"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert users_table.update.call_count == 2


### PR DESCRIPTION
## Summary
Fixes the production Stripe webhook crash where test-mode events to `/stripe/webhook` returned HTTP 500 with `type=AttributeError` and `detail=get` for `checkout.session.completed`, `customer.subscription.created`, and `customer.subscription.deleted`.

## Root cause
The webhook path assumed Stripe event/session/subscription objects were dict-like and supported `.get()`, including:
- `event.get("type")` / `event.get("data")`
- `data_obj.get(...)`
- nested subscription item and price lookups through chained `.get()` calls

Production Stripe SDK payloads can be StripeObject-style/attribute-only, so those `.get()` calls can crash before entitlement handling runs.

## Changes
- Add safe Stripe access helpers that handle mappings, StripeObject-style attributes, and list-object `.data` shapes.
- Route checkout/session subscription, subscription created/updated, and subscription deleted events through shared object-shape-safe entitlement handling.
- Preserve mandatory Stripe signature verification via `stripe.Webhook.construct_event(...)`.
- Keep required entitlement writes strict: successful user entitlement writes return 2xx, required DB/Supabase write failures return non-2xx for retry.
- Map deleted/terminal subscription states to `plan=free` in webhook and reconciliation paths.
- Add attr-only regression tests for checkout completed, subscription created, subscription deleted, unknown price retryability, idempotent retry, and reconciliation canceled-to-free handling.
- Update E2E smoke workflow to use project-installed Playwright and collect/run only `e2e/production-smoke.spec.ts` with `playwright.production.config.ts`.

## Guardrails
- No Stripe product, price, or pricing changes.
- No Sprint 2B or Sprint 3 work.
- No `.env` file committed.
- No secrets added; added fake webhook-secret-looking test literals were replaced with neutral test strings.
- Signature verification was not disabled or weakened.
- No success-page entitlement granting and no code cancellation of duplicate subscriptions.

## Validation
- Targeted backend Stripe/reconciliation tests: 44 passed before final cleanup.
- Final touched backend tests: 26 passed after Black formatting.
- Full backend test suite: passed.
- Frontend Jest: 74 suites / 335 tests passed.
- Frontend lint: passed.
- Playwright production smoke list: 5 tests only from `e2e/production-smoke.spec.ts`.
- `git diff --check`: passed.
- Workflow YAML parse: passed.
- Frontend production build was attempted once and exited 143 after `Creating an optimized production build ...`.