### PR TITLE
fix(stripe): automate safe test entitlement repair

### DIFF
--- a/.github/workflows/stripe-entitlement-repair.yml
+++ b/.github/workflows/stripe-entitlement-repair.yml
@@ -208,6 +208,7 @@ jobs:
         id: apply
         if: ${{ inputs.apply_changes }}
         env:
+          STRIPE_TEST_RESTRICTED_KEY: ${{ secrets.STRIPE_TEST_RESTRICTED_KEY }}
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           set -euo pipefail
@@ -217,12 +218,40 @@ jobs:
           match_result="${{ steps.analyze.outputs.railway_match_result }}"
           variable_name="${{ steps.analyze.outputs.mapped_railway_variable }}"
           price_id="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["price_id"])' "$context_json")"
+          current_price_id="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get("current_railway_price_id") or "")' "$context_json")"
+          if [ -n "$current_price_id" ]; then
+            echo "::add-mask::$current_price_id"
+          fi
 
           if [ "$match_result" = "MATCH" ]; then
             echo "deployment_needed=no" >> "$GITHUB_OUTPUT"
             echo "Railway variable already matches; no production variable was changed." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+
+          if [ -n "$current_price_id" ]; then
+            stripe subscriptions list \
+              --price "$current_price_id" \
+              --status active \
+              --limit 100 \
+              --api-key "$STRIPE_TEST_RESTRICTED_KEY" \
+              > "$REPAIR_TMP/old-price-active-subscriptions.json"
+            stripe subscriptions list \
+              --price "$current_price_id" \
+              --status trialing \
+              --limit 100 \
+              --api-key "$STRIPE_TEST_RESTRICTED_KEY" \
+              > "$REPAIR_TMP/old-price-trialing-subscriptions.json"
+          else
+            printf '{"data": []}\n' > "$REPAIR_TMP/old-price-active-subscriptions.json"
+            printf '{"data": []}\n' > "$REPAIR_TMP/old-price-trialing-subscriptions.json"
+          fi
+
+          python backend/scripts/stripe_entitlement_repair.py validate-overwrite \
+            --context-json "$context_json" \
+            --subscriptions-json "$REPAIR_TMP/subscriptions.json" \
+            --subscriptions-json "$REPAIR_TMP/old-price-active-subscriptions.json" \
+            --subscriptions-json "$REPAIR_TMP/old-price-trialing-subscriptions.json"
 
           railway variable set "${variable_name}=${price_id}" \
             --service "$RAILWAY_API_SERVICE" \
@@ -241,6 +270,7 @@ jobs:
         run: |
           set -euo pipefail
           set +x
+          printf '%s' "${GITHUB_SHA}" > backend/.app_version
           railway up \
             --service "$RAILWAY_API_SERVICE" \
             --ci \
@@ -255,18 +285,27 @@ jobs:
           set +x
           deadline=$((SECONDS + 180))
           attempt=0
+          expected_version="${GITHUB_SHA}"
           while [ "$SECONDS" -lt "$deadline" ]; do
             attempt=$((attempt + 1))
             code="$(curl -sS -o "$REPAIR_TMP/health.json" -w "%{http_code}" --max-time 8 "$BACKEND_HEALTH_URL" || true)"
             if [ "$code" = "200" ]; then
-              echo "Backend health check passed." >> "$GITHUB_STEP_SUMMARY"
-              exit 0
+              if [ "${{ steps.apply.outputs.deployment_needed }}" != "yes" ]; then
+                echo "Backend health check passed." >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+
+              actual_version="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get("version", ""))' "$REPAIR_TMP/health.json" || true)"
+              if [ "$actual_version" = "$expected_version" ]; then
+                echo "Backend health check passed on the repaired deployment." >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
             fi
             echo "Health attempt $attempt returned HTTP ${code:-curl_failed}."
             sleep 5
           done
 
-          echo "::error::Backend health did not return 200 within 180 seconds."
+          echo "::error::Backend health did not confirm the repaired deployment within 180 seconds."
           if [ -s "$REPAIR_TMP/health.json" ]; then
             python -c 'import json, sys; payload = json.load(open(sys.argv[1], encoding="utf-8")); print("Safe health diagnostics:", {"status": payload.get("status"), "version_present": bool(payload.get("version"))})' "$REPAIR_TMP/health.json" || echo "Safe health diagnostics unavailable"
           fi
@@ -294,7 +333,8 @@ jobs:
             --api-key "$STRIPE_TEST_RESTRICTED_KEY" \
             > "$REPAIR_TMP/event.json"
           python backend/scripts/stripe_entitlement_repair.py validate-event \
-            --event-json "$REPAIR_TMP/event.json"
+            --event-json "$REPAIR_TMP/event.json" \
+            --context-json "$REPAIR_TMP/context.json"
 
       - name: Resend failed Stripe event to production webhook
         id: resend

--- a/.github/workflows/stripe-entitlement-repair.yml
+++ b/.github/workflows/stripe-entitlement-repair.yml
@@ -1,0 +1,372 @@
+name: Stripe Entitlement Repair
+
+on:
+  workflow_dispatch:
+    inputs:
+      email:
+        description: Stripe customer email
+        required: true
+        default: abbas_m90@hotmail.com
+      expected_plan:
+        description: Expected PropNexus plan
+        type: choice
+        options:
+          - starter
+          - investor_pro
+        default: starter
+      failed_event_id:
+        description: Optional Stripe evt_ ID to resend
+        required: false
+      apply_changes:
+        description: Apply the Railway environment repair
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    env:
+      RAILWAY_API_SERVICE: propnexus-backend
+      BACKEND_HEALTH_URL: https://propnexus-backend-production.up.railway.app/health
+      PRODUCTION_WEBHOOK_URL: https://propnexus-backend-production.up.railway.app/stripe/webhook
+      STRIPE_CLI_VERSION: "1.23.10"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare secure workspace
+        run: |
+          set -euo pipefail
+          set +x
+          umask 077
+          repair_tmp="$(mktemp -d)"
+          echo "REPAIR_TMP=$repair_tmp" >> "$GITHUB_ENV"
+
+      - name: Validate required secrets
+        env:
+          STRIPE_TEST_RESTRICTED_KEY: ${{ secrets.STRIPE_TEST_RESTRICTED_KEY }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          set -euo pipefail
+          set +x
+
+          python backend/scripts/stripe_entitlement_repair.py validate-key
+          if [ -z "${RAILWAY_TOKEN:-}" ]; then
+            echo "::error::RAILWAY_TOKEN is required"
+            exit 1
+          fi
+
+      - name: Resolve plan mapping
+        id: plan
+        run: |
+          set -euo pipefail
+          set +x
+          python backend/scripts/stripe_entitlement_repair.py plan \
+            --expected-plan "${{ inputs.expected_plan }}"
+
+      - name: Install Stripe CLI
+        run: |
+          set -euo pipefail
+          set +x
+          mkdir -p "$RUNNER_TEMP/bin"
+          archive="$RUNNER_TEMP/stripe-cli.tar.gz"
+          curl -fsSL \
+            "https://github.com/stripe/stripe-cli/releases/download/v${STRIPE_CLI_VERSION}/stripe_${STRIPE_CLI_VERSION}_linux_x86_64.tar.gz" \
+            -o "$archive"
+          tar -xzf "$archive" -C "$RUNNER_TEMP/bin" stripe
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          stripe version
+
+      - name: Install Railway CLI
+        run: |
+          set -euo pipefail
+          set +x
+          if curl -fsSL https://railway.app/install.sh | sh; then
+            echo "$HOME/.railway/bin" >> "$GITHUB_PATH"
+          else
+            npm install -g @railway/cli
+            echo "$(npm bin -g)" >> "$GITHUB_PATH"
+          fi
+          railway --version
+
+      - name: Find exact Stripe customer
+        id: customer
+        env:
+          STRIPE_TEST_RESTRICTED_KEY: ${{ secrets.STRIPE_TEST_RESTRICTED_KEY }}
+          INPUT_EMAIL: ${{ inputs.email }}
+        run: |
+          set -euo pipefail
+          set +x
+
+          normalized_email="$(python -c 'import os; print(os.environ["INPUT_EMAIL"].strip().lower())')"
+          customers_json="$REPAIR_TMP/customers.json"
+          customer_json="$REPAIR_TMP/customer.json"
+
+          stripe customers search \
+            --query "email:'${normalized_email}'" \
+            --limit 10 \
+            --api-key "$STRIPE_TEST_RESTRICTED_KEY" \
+            > "$customers_json"
+
+          python backend/scripts/stripe_entitlement_repair.py select-customer \
+            --email "$normalized_email" \
+            --customers-json "$customers_json" \
+            --output-json "$customer_json"
+
+          customer_id="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["id"])' "$customer_json")"
+          echo "::add-mask::$customer_id"
+
+      - name: Find latest eligible subscription
+        id: subscription
+        env:
+          STRIPE_TEST_RESTRICTED_KEY: ${{ secrets.STRIPE_TEST_RESTRICTED_KEY }}
+        run: |
+          set -euo pipefail
+          set +x
+
+          customer_json="$REPAIR_TMP/customer.json"
+          subscriptions_json="$REPAIR_TMP/subscriptions.json"
+          subscription_json="$REPAIR_TMP/subscription.json"
+          customer_id="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["id"])' "$customer_json")"
+
+          stripe subscriptions list \
+            --customer "$customer_id" \
+            --status all \
+            --limit 20 \
+            --api-key "$STRIPE_TEST_RESTRICTED_KEY" \
+            > "$subscriptions_json"
+
+          python backend/scripts/stripe_entitlement_repair.py select-subscription \
+            --subscriptions-json "$subscriptions_json" \
+            --output-json "$subscription_json"
+
+          subscription_id="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["subscription"]["id"])' "$subscription_json")"
+          price_id="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["price_id"])' "$subscription_json")"
+          echo "::add-mask::$subscription_id"
+          echo "::add-mask::$price_id"
+
+      - name: Retrieve Stripe price and Railway variables
+        id: analyze
+        env:
+          STRIPE_TEST_RESTRICTED_KEY: ${{ secrets.STRIPE_TEST_RESTRICTED_KEY }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          set -euo pipefail
+          set +x
+
+          subscription_json="$REPAIR_TMP/subscription.json"
+          price_json="$REPAIR_TMP/price.json"
+          railway_json="$REPAIR_TMP/railway-vars.json"
+          context_json="$REPAIR_TMP/context.json"
+          price_id="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["price_id"])' "$subscription_json")"
+
+          stripe prices retrieve "$price_id" \
+            --api-key "$STRIPE_TEST_RESTRICTED_KEY" \
+            > "$price_json"
+
+          railway variables \
+            --service "$RAILWAY_API_SERVICE" \
+            --json \
+            > "$railway_json"
+
+          python backend/scripts/stripe_entitlement_repair.py analyze \
+            --email "${{ inputs.email }}" \
+            --expected-plan "${{ inputs.expected_plan }}" \
+            --customer-json "$REPAIR_TMP/customer.json" \
+            --subscription-json "$subscription_json" \
+            --price-json "$price_json" \
+            --railway-json "$railway_json" \
+            --duplicate-subscription-warning "${{ steps.subscription.outputs.duplicate_subscription_warning }}" \
+            --output-json "$context_json"
+
+          python backend/scripts/stripe_entitlement_repair.py summary \
+            --context-json "$context_json"
+
+      - name: Dry-run stop
+        if: ${{ !inputs.apply_changes }}
+        run: |
+          set -euo pipefail
+          set +x
+          echo "Dry run complete. No Railway variables were changed and no Stripe event was resent." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate apply preconditions
+        if: ${{ inputs.apply_changes }}
+        run: |
+          set -euo pipefail
+          set +x
+          if [ "${{ steps.analyze.outputs.apply_allowed }}" != "yes" ]; then
+            echo "::error::Selected subscription is not active or trialing; apply mode is blocked."
+            exit 1
+          fi
+
+      - name: Apply Railway variable repair
+        id: apply
+        if: ${{ inputs.apply_changes }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          set -euo pipefail
+          set +x
+
+          context_json="$REPAIR_TMP/context.json"
+          match_result="${{ steps.analyze.outputs.railway_match_result }}"
+          variable_name="${{ steps.analyze.outputs.mapped_railway_variable }}"
+          price_id="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["price_id"])' "$context_json")"
+
+          if [ "$match_result" = "MATCH" ]; then
+            echo "deployment_needed=no" >> "$GITHUB_OUTPUT"
+            echo "Railway variable already matches; no production variable was changed." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          railway variable set "${variable_name}=${price_id}" \
+            --service "$RAILWAY_API_SERVICE" \
+            --skip-deploys \
+            > "$REPAIR_TMP/railway-set.out" \
+            2> "$REPAIR_TMP/railway-set.err"
+
+          echo "deployment_needed=yes" >> "$GITHUB_OUTPUT"
+          echo "Updated selected Railway variable without printing its value." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Redeploy backend when repaired
+        id: deploy
+        if: ${{ inputs.apply_changes && steps.apply.outputs.deployment_needed == 'yes' }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          set -euo pipefail
+          set +x
+          railway up \
+            --service "$RAILWAY_API_SERVICE" \
+            --ci \
+            --json \
+            > "$REPAIR_TMP/railway-deploy.json"
+
+      - name: Wait for backend health
+        id: health
+        if: ${{ inputs.apply_changes }}
+        run: |
+          set -euo pipefail
+          set +x
+          deadline=$((SECONDS + 180))
+          attempt=0
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            attempt=$((attempt + 1))
+            code="$(curl -sS -o "$REPAIR_TMP/health.json" -w "%{http_code}" --max-time 8 "$BACKEND_HEALTH_URL" || true)"
+            if [ "$code" = "200" ]; then
+              echo "Backend health check passed." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "Health attempt $attempt returned HTTP ${code:-curl_failed}."
+            sleep 5
+          done
+
+          echo "::error::Backend health did not return 200 within 180 seconds."
+          if [ -s "$REPAIR_TMP/health.json" ]; then
+            python -c 'import json, sys; payload = json.load(open(sys.argv[1], encoding="utf-8")); print("Safe health diagnostics:", {"status": payload.get("status"), "version_present": bool(payload.get("version"))})' "$REPAIR_TMP/health.json" || echo "Safe health diagnostics unavailable"
+          fi
+          exit 1
+
+      - name: Validate optional event resend request
+        id: event_request
+        if: ${{ inputs.apply_changes && steps.health.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          set +x
+          python backend/scripts/stripe_entitlement_repair.py validate-event-id \
+            --event-id "${{ inputs.failed_event_id }}"
+
+      - name: Retrieve and validate failed Stripe event
+        if: ${{ inputs.apply_changes && steps.event_request.outputs.resend_requested == 'yes' }}
+        env:
+          STRIPE_TEST_RESTRICTED_KEY: ${{ secrets.STRIPE_TEST_RESTRICTED_KEY }}
+        run: |
+          set -euo pipefail
+          set +x
+          event_id="${{ inputs.failed_event_id }}"
+          echo "::add-mask::$event_id"
+          stripe events retrieve "$event_id" \
+            --api-key "$STRIPE_TEST_RESTRICTED_KEY" \
+            > "$REPAIR_TMP/event.json"
+          python backend/scripts/stripe_entitlement_repair.py validate-event \
+            --event-json "$REPAIR_TMP/event.json"
+
+      - name: Resend failed Stripe event to production webhook
+        id: resend
+        if: ${{ inputs.apply_changes && steps.event_request.outputs.resend_requested == 'yes' }}
+        env:
+          STRIPE_TEST_RESTRICTED_KEY: ${{ secrets.STRIPE_TEST_RESTRICTED_KEY }}
+        run: |
+          set -euo pipefail
+          set +x
+          endpoints_json="$REPAIR_TMP/webhook-endpoints.json"
+          endpoint_json="$REPAIR_TMP/webhook-endpoint.json"
+
+          stripe webhook_endpoints list \
+            --limit 100 \
+            --api-key "$STRIPE_TEST_RESTRICTED_KEY" \
+            > "$endpoints_json"
+
+          python backend/scripts/stripe_entitlement_repair.py select-endpoint \
+            --endpoints-json "$endpoints_json" \
+            --url "$PRODUCTION_WEBHOOK_URL" \
+            --output-json "$endpoint_json"
+
+          endpoint_id="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["id"])' "$endpoint_json")"
+          event_id="${{ inputs.failed_event_id }}"
+          echo "::add-mask::$endpoint_id"
+          echo "::add-mask::$event_id"
+
+          stripe events resend "$event_id" \
+            --webhook-endpoint="$endpoint_id" \
+            --api-key "$STRIPE_TEST_RESTRICTED_KEY" \
+            > "$REPAIR_TMP/resend.json"
+
+          echo "resend_accepted=yes" >> "$GITHUB_OUTPUT"
+          echo "Stripe accepted the event resend request." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post-repair verification path
+        if: ${{ inputs.apply_changes }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          E2E_STARTER_EMAIL: ${{ secrets.E2E_STARTER_EMAIL }}
+          E2E_STARTER_PASSWORD: ${{ secrets.E2E_STARTER_PASSWORD }}
+          E2E_PRO_EMAIL: ${{ secrets.E2E_PRO_EMAIL }}
+          E2E_PRO_PASSWORD: ${{ secrets.E2E_PRO_PASSWORD }}
+        run: |
+          set -euo pipefail
+          set +x
+          if [ "${{ steps.event_request.outputs.resend_requested }}" = "yes" ]; then
+            sleep 10
+          fi
+
+          if [ "${{ inputs.expected_plan }}" = "starter" ]; then
+            email_present="$E2E_STARTER_EMAIL"
+            password_present="$E2E_STARTER_PASSWORD"
+          else
+            email_present="$E2E_PRO_EMAIL"
+            password_present="$E2E_PRO_PASSWORD"
+          fi
+
+          if [ -n "$email_present" ] && [ -n "$password_present" ]; then
+            gh workflow run e2e-smoke.yml \
+              --ref main \
+              -f E2E_BASE_URL=https://propnexus-platform.vercel.app
+            echo "Authenticated production smoke workflow was dispatched for final plan verification." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Webhook resend succeeded; refresh /account and confirm Investor Starter or Investor Pro." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Cleanup temporary files
+        if: always()
+        run: |
+          set -euo pipefail
+          set +x
+          if [ -n "${REPAIR_TMP:-}" ] && [ -d "$REPAIR_TMP" ]; then
+            rm -rf "$REPAIR_TMP"
+          fi

--- a/backend/scripts/stripe_entitlement_repair.py
+++ b/backend/scripts/stripe_entitlement_repair.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ELIGIBLE_STATUSES = {"trialing", "active"}
+ALLOWED_EVENT_TYPES = {
+    "checkout.session.completed",
+    "customer.subscription.created",
+    "customer.subscription.updated",
+    "customer.subscription.deleted",
+}
+
+
+@dataclass(frozen=True)
+class PlanMapping:
+    railway_price_variable: str
+    railway_product_variable: str
+    backend_plan: str
+
+
+PLAN_MAPPINGS = {
+    "starter": PlanMapping(
+        railway_price_variable="STRIPE_PRICE_PRO",
+        railway_product_variable="STRIPE_PRODUCT_PRO",
+        backend_plan="pro",
+    ),
+    "investor_pro": PlanMapping(
+        railway_price_variable="STRIPE_PRICE_INVESTOR",
+        railway_product_variable="STRIPE_PRODUCT_INVESTOR",
+        backend_plan="investor",
+    ),
+}
+
+
+class RepairError(RuntimeError):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+def load_json(path: str | Path) -> Any:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: str | Path, payload: Any) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def normalize_email(email: str | None) -> str:
+    return str(email or "").strip().lower()
+
+
+def validate_stripe_key(value: str | None) -> None:
+    if not value:
+        raise RepairError("missing_stripe_key", "STRIPE_TEST_RESTRICTED_KEY is required")
+    if value.startswith(("sk_live_", "rk_live_")):
+        raise RepairError("live_stripe_key", "Live Stripe keys are not allowed")
+    if not value.startswith(("sk_test_", "rk_test_")):
+        raise RepairError(
+            "invalid_stripe_key", "Stripe key must be a test-mode secret or restricted key"
+        )
+
+
+def plan_mapping(expected_plan: str) -> PlanMapping:
+    try:
+        return PLAN_MAPPINGS[expected_plan]
+    except KeyError as exc:
+        raise RepairError("unknown_expected_plan", "Expected plan cannot be mapped") from exc
+
+
+def data_items(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        data = payload.get("data", [])
+    else:
+        data = []
+    return [item for item in data if isinstance(item, dict)]
+
+
+def stripe_id(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        object_id = value.get("id")
+        return str(object_id) if object_id else None
+    return None
+
+
+def redact_identifier(value: str | None) -> str:
+    if not value:
+        return "missing"
+    if "_" in value:
+        prefix = value.split("_", 1)[0]
+        return f"{prefix}_...[redacted]"
+    return "[redacted]"
+
+
+def exact_email_customers(customers_payload: Any, email: str) -> list[dict[str, Any]]:
+    expected = normalize_email(email)
+    return [
+        item
+        for item in data_items(customers_payload)
+        if normalize_email(str(item.get("email", ""))) == expected
+    ]
+
+
+def select_customer(customers_payload: Any, email: str) -> dict[str, Any]:
+    matches = exact_email_customers(customers_payload, email)
+    if not matches:
+        raise RepairError("customer_not_found", "No customer found for the exact email")
+    if len(matches) > 1:
+        raise RepairError("ambiguous_customer", "Multiple customers matched the exact email")
+    customer_id = stripe_id(matches[0])
+    if not customer_id:
+        raise RepairError("customer_missing_id", "Matched customer has no identifier")
+    return matches[0]
+
+
+def subscription_sort_key(subscription: dict[str, Any]) -> tuple[int, int]:
+    status_rank = 0 if subscription.get("status") == "trialing" else 1
+    created = int(subscription.get("created") or 0)
+    return status_rank, -created
+
+
+def select_subscription(subscriptions_payload: Any) -> tuple[dict[str, Any], bool]:
+    subscriptions = data_items(subscriptions_payload)
+    eligible = [item for item in subscriptions if item.get("status") in ELIGIBLE_STATUSES]
+    if not eligible:
+        raise RepairError("subscription_not_found", "No active or trialing subscription found")
+
+    ordered = sorted(eligible, key=subscription_sort_key)
+    selected = ordered[0]
+    if len(ordered) > 1:
+        first_key = subscription_sort_key(ordered[0])
+        second_key = subscription_sort_key(ordered[1])
+        if first_key == second_key:
+            raise RepairError(
+                "ambiguous_subscription",
+                "Multiple eligible subscriptions have the same status and created timestamp",
+            )
+
+    subscription_id = stripe_id(selected)
+    if not subscription_id:
+        raise RepairError("subscription_missing_id", "Selected subscription has no identifier")
+    return selected, len(eligible) > 1
+
+
+def subscription_recurring_price_id(subscription: dict[str, Any]) -> str:
+    items = data_items(subscription.get("items", {}))
+    for item in items:
+        price = item.get("price")
+        if not isinstance(price, dict):
+            continue
+        if not price.get("recurring"):
+            continue
+        price_id = stripe_id(price)
+        if price_id:
+            return price_id
+    raise RepairError("missing_recurring_price", "Selected subscription has no recurring price")
+
+
+def parse_railway_variables(payload: Any) -> dict[str, str]:
+    if isinstance(payload, dict):
+        if all(isinstance(key, str) for key in payload):
+            return {str(key): str(value) for key, value in payload.items() if value is not None}
+        variables = payload.get("variables") or payload.get("data") or []
+    else:
+        variables = payload
+
+    parsed: dict[str, str] = {}
+    if isinstance(variables, list):
+        for item in variables:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name") or item.get("key")
+            value = item.get("value")
+            if name and value is not None:
+                parsed[str(name)] = str(value)
+    return parsed
+
+
+def railway_match_result(
+    variables: dict[str, str], variable_name: str, discovered_value: str
+) -> str:
+    current = variables.get(variable_name)
+    if not current:
+        return "MISSING"
+    return "MATCH" if current == discovered_value else "MISMATCH"
+
+
+def validate_price(price: dict[str, Any], expected_product: str | None) -> None:
+    if price.get("livemode") is not False:
+        raise RepairError("price_not_test_mode", "Selected price is not a test-mode price")
+    if price.get("active") is not True:
+        raise RepairError("price_inactive", "Selected price is inactive")
+    if not price.get("recurring"):
+        raise RepairError("price_not_recurring", "Selected price is not recurring")
+    if not expected_product:
+        raise RepairError(
+            "expected_product_missing", "Expected Railway product variable is missing"
+        )
+    if price.get("product") != expected_product:
+        raise RepairError(
+            "unexpected_product", "Selected price does not belong to the expected product"
+        )
+
+
+def can_apply_subscription(status: str | None) -> bool:
+    return status in ELIGIBLE_STATUSES
+
+
+def validate_event_id(event_id: str | None) -> None:
+    if not event_id:
+        raise RepairError("event_id_missing", "No event ID supplied")
+    if not re.match(r"^evt_[A-Za-z0-9]+$", event_id):
+        raise RepairError("malformed_event_id", "Stripe event ID must begin with the event prefix")
+
+
+def validate_event(event: dict[str, Any]) -> None:
+    if event.get("livemode") is not False:
+        raise RepairError("event_not_test_mode", "Live-mode events are not allowed")
+    event_type = event.get("type")
+    if event_type not in ALLOWED_EVENT_TYPES:
+        raise RepairError("unknown_event_type", "Event type is not allowed for this repair")
+
+
+def select_webhook_endpoint(payload: Any, url: str) -> dict[str, Any]:
+    matches = [item for item in data_items(payload) if item.get("url") == url]
+    if not matches:
+        raise RepairError("webhook_endpoint_not_found", "Production webhook endpoint was not found")
+    enabled = [item for item in matches if item.get("status") in (None, "enabled")]
+    if len(enabled) != 1:
+        raise RepairError(
+            "ambiguous_webhook_endpoint", "Production webhook endpoint selection is ambiguous"
+        )
+    endpoint_id = stripe_id(enabled[0])
+    if not endpoint_id:
+        raise RepairError("webhook_endpoint_missing_id", "Webhook endpoint has no identifier")
+    return enabled[0]
+
+
+def safe_context(
+    *,
+    email: str,
+    expected_plan: str,
+    customer: dict[str, Any] | None,
+    subscription: dict[str, Any] | None,
+    price: dict[str, Any] | None,
+    railway_variables: dict[str, str],
+    duplicate_subscription_warning: bool,
+) -> dict[str, Any]:
+    mapping = plan_mapping(expected_plan)
+    price_id = stripe_id(price) if price else None
+    status = subscription.get("status") if subscription else None
+    result = railway_match_result(railway_variables, mapping.railway_price_variable, price_id or "")
+    return {
+        "customer_found": "yes" if customer else "no",
+        "eligible_subscription_found": "yes" if subscription else "no",
+        "stripe_status": status or "missing",
+        "expected_backend_plan": mapping.backend_plan,
+        "mapped_railway_variable": mapping.railway_price_variable,
+        "railway_match_result": result,
+        "duplicate_subscription_warning": "yes" if duplicate_subscription_warning else "no",
+        "required_next_action": (
+            "none" if result == "MATCH" else "apply repair with apply_changes=true"
+        ),
+        "redacted_price": redact_identifier(price_id),
+        "normalized_email": normalize_email(email),
+    }
+
+
+def print_github_outputs(values: dict[str, Any]) -> None:
+    output_path = os.getenv("GITHUB_OUTPUT")
+    lines = [f"{key}={value}" for key, value in values.items()]
+    if output_path:
+        with Path(output_path).open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+    else:
+        print("\n".join(lines))
+
+
+def command_validate_key(_args: argparse.Namespace) -> int:
+    validate_stripe_key(os.getenv("STRIPE_TEST_RESTRICTED_KEY"))
+    return 0
+
+
+def command_plan(args: argparse.Namespace) -> int:
+    mapping = plan_mapping(args.expected_plan)
+    print_github_outputs(
+        {
+            "railway_price_variable": mapping.railway_price_variable,
+            "railway_product_variable": mapping.railway_product_variable,
+            "backend_plan": mapping.backend_plan,
+        }
+    )
+    return 0
+
+
+def command_select_customer(args: argparse.Namespace) -> int:
+    customer = select_customer(load_json(args.customers_json), args.email)
+    write_json(args.output_json, customer)
+    print_github_outputs({"customer_found": "yes"})
+    return 0
+
+
+def command_select_subscription(args: argparse.Namespace) -> int:
+    subscription, duplicate_warning = select_subscription(load_json(args.subscriptions_json))
+    price_id = subscription_recurring_price_id(subscription)
+    write_json(args.output_json, {"subscription": subscription, "price_id": price_id})
+    print_github_outputs(
+        {
+            "eligible_subscription_found": "yes",
+            "stripe_status": subscription.get("status", "missing"),
+            "duplicate_subscription_warning": "yes" if duplicate_warning else "no",
+        }
+    )
+    return 0
+
+
+def command_analyze(args: argparse.Namespace) -> int:
+    mapping = plan_mapping(args.expected_plan)
+    customer = load_json(args.customer_json)
+    subscription_payload = load_json(args.subscription_json)
+    subscription = subscription_payload["subscription"]
+    price = load_json(args.price_json)
+    railway_variables = parse_railway_variables(load_json(args.railway_json))
+    validate_price(price, railway_variables.get(mapping.railway_product_variable))
+    price_id = stripe_id(price)
+    if not price_id:
+        raise RepairError("price_missing_id", "Selected price has no identifier")
+    result = railway_match_result(railway_variables, mapping.railway_price_variable, price_id)
+    context = safe_context(
+        email=args.email,
+        expected_plan=args.expected_plan,
+        customer=customer,
+        subscription=subscription,
+        price=price,
+        railway_variables=railway_variables,
+        duplicate_subscription_warning=args.duplicate_subscription_warning == "yes",
+    )
+    context.update(
+        {
+            "customer_id": stripe_id(customer),
+            "subscription_id": stripe_id(subscription),
+            "price_id": price_id,
+            "railway_product_variable": mapping.railway_product_variable,
+            "apply_allowed": "yes" if can_apply_subscription(subscription.get("status")) else "no",
+        }
+    )
+    write_json(args.output_json, context)
+    print_github_outputs(
+        {
+            "railway_match_result": result,
+            "mapped_railway_variable": mapping.railway_price_variable,
+            "backend_plan": mapping.backend_plan,
+            "apply_allowed": context["apply_allowed"],
+        }
+    )
+    return 0
+
+
+def command_validate_event_id(args: argparse.Namespace) -> int:
+    if not args.event_id:
+        print_github_outputs({"resend_requested": "no"})
+        return 0
+    validate_event_id(args.event_id)
+    print_github_outputs({"resend_requested": "yes"})
+    return 0
+
+
+def command_validate_event(args: argparse.Namespace) -> int:
+    validate_event(load_json(args.event_json))
+    return 0
+
+
+def command_select_endpoint(args: argparse.Namespace) -> int:
+    endpoint = select_webhook_endpoint(load_json(args.endpoints_json), args.url)
+    write_json(args.output_json, endpoint)
+    return 0
+
+
+def command_summary(args: argparse.Namespace) -> int:
+    context = load_json(args.context_json)
+    lines = [
+        "## Stripe entitlement repair summary",
+        "",
+        f"- customer found: {context.get('customer_found', 'no')}",
+        f"- eligible subscription found: {context.get('eligible_subscription_found', 'no')}",
+        f"- Stripe status: {context.get('stripe_status', 'missing')}",
+        f"- expected backend plan: {context.get('expected_backend_plan', 'missing')}",
+        f"- mapped Railway variable name: {context.get('mapped_railway_variable', 'missing')}",
+        f"- Railway match result: {context.get('railway_match_result', 'MISSING')}",
+        f"- duplicate subscription warning: {context.get('duplicate_subscription_warning', 'no')}",
+        f"- required next action: {context.get('required_next_action', 'manual review')}",
+    ]
+    target = os.getenv("GITHUB_STEP_SUMMARY")
+    if target:
+        with Path(target).open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+    else:
+        print("\n".join(lines))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Safe Stripe entitlement repair workflow helper")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("validate-key").set_defaults(func=command_validate_key)
+
+    plan_parser = subparsers.add_parser("plan")
+    plan_parser.add_argument("--expected-plan", required=True)
+    plan_parser.set_defaults(func=command_plan)
+
+    customer_parser = subparsers.add_parser("select-customer")
+    customer_parser.add_argument("--email", required=True)
+    customer_parser.add_argument("--customers-json", required=True)
+    customer_parser.add_argument("--output-json", required=True)
+    customer_parser.set_defaults(func=command_select_customer)
+
+    subscription_parser = subparsers.add_parser("select-subscription")
+    subscription_parser.add_argument("--subscriptions-json", required=True)
+    subscription_parser.add_argument("--output-json", required=True)
+    subscription_parser.set_defaults(func=command_select_subscription)
+
+    analyze_parser = subparsers.add_parser("analyze")
+    analyze_parser.add_argument("--email", required=True)
+    analyze_parser.add_argument("--expected-plan", required=True)
+    analyze_parser.add_argument("--customer-json", required=True)
+    analyze_parser.add_argument("--subscription-json", required=True)
+    analyze_parser.add_argument("--price-json", required=True)
+    analyze_parser.add_argument("--railway-json", required=True)
+    analyze_parser.add_argument("--duplicate-subscription-warning", required=True)
+    analyze_parser.add_argument("--output-json", required=True)
+    analyze_parser.set_defaults(func=command_analyze)
+
+    event_id_parser = subparsers.add_parser("validate-event-id")
+    event_id_parser.add_argument("--event-id", default="")
+    event_id_parser.set_defaults(func=command_validate_event_id)
+
+    event_parser = subparsers.add_parser("validate-event")
+    event_parser.add_argument("--event-json", required=True)
+    event_parser.set_defaults(func=command_validate_event)
+
+    endpoint_parser = subparsers.add_parser("select-endpoint")
+    endpoint_parser.add_argument("--endpoints-json", required=True)
+    endpoint_parser.add_argument("--url", required=True)
+    endpoint_parser.add_argument("--output-json", required=True)
+    endpoint_parser.set_defaults(func=command_select_endpoint)
+
+    summary_parser = subparsers.add_parser("summary")
+    summary_parser.add_argument("--context-json", required=True)
+    summary_parser.set_defaults(func=command_summary)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except RepairError as exc:
+        print(json.dumps({"ok": False, "error": exc.code, "message": str(exc)}), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/stripe_entitlement_repair.py
+++ b/backend/scripts/stripe_entitlement_repair.py
@@ -16,6 +16,11 @@ ALLOWED_EVENT_TYPES = {
     "customer.subscription.updated",
     "customer.subscription.deleted",
 }
+SUBSCRIPTION_EVENT_TYPES = {
+    "customer.subscription.created",
+    "customer.subscription.updated",
+    "customer.subscription.deleted",
+}
 
 
 @dataclass(frozen=True)
@@ -84,6 +89,10 @@ def data_items(payload: Any) -> list[dict[str, Any]]:
     else:
         data = []
     return [item for item in data if isinstance(item, dict)]
+
+
+def payload_has_more(payload: Any) -> bool:
+    return isinstance(payload, dict) and payload.get("has_more") is True
 
 
 def stripe_id(value: Any) -> str | None:
@@ -168,6 +177,28 @@ def subscription_recurring_price_id(subscription: dict[str, Any]) -> str:
     raise RepairError("missing_recurring_price", "Selected subscription has no recurring price")
 
 
+def subscription_uses_price(subscription: dict[str, Any], price_id: str) -> bool:
+    if subscription.get("status") not in ELIGIBLE_STATUSES:
+        return False
+    try:
+        return subscription_recurring_price_id(subscription) == price_id
+    except RepairError:
+        return False
+
+
+def has_other_eligible_subscribers(
+    subscriptions_payload: Any, *, selected_subscription_id: str, old_price_id: str | None
+) -> bool:
+    if not old_price_id:
+        return False
+    for subscription in data_items(subscriptions_payload):
+        if stripe_id(subscription) == selected_subscription_id:
+            continue
+        if subscription_uses_price(subscription, old_price_id):
+            return True
+    return False
+
+
 def parse_railway_variables(payload: Any) -> dict[str, str]:
     if isinstance(payload, dict):
         if all(isinstance(key, str) for key in payload):
@@ -231,6 +262,47 @@ def validate_event(event: dict[str, Any]) -> None:
     event_type = event.get("type")
     if event_type not in ALLOWED_EVENT_TYPES:
         raise RepairError("unknown_event_type", "Event type is not allowed for this repair")
+
+
+def event_data_object(event: dict[str, Any]) -> dict[str, Any]:
+    data = event.get("data")
+    if not isinstance(data, dict):
+        return {}
+    data_object = data.get("object")
+    return data_object if isinstance(data_object, dict) else {}
+
+
+def event_customer_id(event: dict[str, Any]) -> str | None:
+    data_object = event_data_object(event)
+    customer = data_object.get("customer")
+    if customer_id := stripe_id(customer):
+        return customer_id
+    customer_details = data_object.get("customer_details")
+    if isinstance(customer_details, dict):
+        return stripe_id(customer_details.get("customer"))
+    return None
+
+
+def event_subscription_id(event: dict[str, Any]) -> str | None:
+    data_object = event_data_object(event)
+    event_type = event.get("type")
+    if event_type in SUBSCRIPTION_EVENT_TYPES:
+        return stripe_id(data_object)
+    return stripe_id(data_object.get("subscription"))
+
+
+def validate_event_binding(event: dict[str, Any], context: dict[str, Any]) -> None:
+    validate_event(event)
+    expected_customer_id = context.get("customer_id")
+    expected_subscription_id = context.get("subscription_id")
+    actual_customer_id = event_customer_id(event)
+    actual_subscription_id = event_subscription_id(event)
+    if not expected_customer_id or actual_customer_id != expected_customer_id:
+        raise RepairError("event_customer_mismatch", "Event customer does not match repair context")
+    if not expected_subscription_id or actual_subscription_id != expected_subscription_id:
+        raise RepairError(
+            "event_subscription_mismatch", "Event subscription does not match repair context"
+        )
 
 
 def select_webhook_endpoint(payload: Any, url: str) -> dict[str, Any]:
@@ -353,6 +425,7 @@ def command_analyze(args: argparse.Namespace) -> int:
             "subscription_id": stripe_id(subscription),
             "price_id": price_id,
             "railway_product_variable": mapping.railway_product_variable,
+            "current_railway_price_id": railway_variables.get(mapping.railway_price_variable),
             "apply_allowed": "yes" if can_apply_subscription(subscription.get("status")) else "no",
         }
     )
@@ -378,7 +451,39 @@ def command_validate_event_id(args: argparse.Namespace) -> int:
 
 
 def command_validate_event(args: argparse.Namespace) -> int:
-    validate_event(load_json(args.event_json))
+    event = load_json(args.event_json)
+    if args.context_json:
+        validate_event_binding(event, load_json(args.context_json))
+    else:
+        validate_event(event)
+    return 0
+
+
+def command_validate_overwrite(args: argparse.Namespace) -> int:
+    context = load_json(args.context_json)
+    selected_subscription_id = context.get("subscription_id")
+    current_price_id = context.get("current_railway_price_id")
+    discovered_price_id = context.get("price_id")
+    if not selected_subscription_id:
+        raise RepairError("subscription_missing_id", "Selected subscription has no identifier")
+    if current_price_id and discovered_price_id and current_price_id == discovered_price_id:
+        return 0
+    for subscriptions_json in args.subscriptions_json:
+        subscriptions_payload = load_json(subscriptions_json)
+        if payload_has_more(subscriptions_payload):
+            raise RepairError(
+                "old_price_subscription_page_truncated",
+                "Old-price subscription inventory was truncated; overwrite cannot be proven safe",
+            )
+        if has_other_eligible_subscribers(
+            subscriptions_payload,
+            selected_subscription_id=selected_subscription_id,
+            old_price_id=current_price_id,
+        ):
+            raise RepairError(
+                "old_price_has_eligible_subscribers",
+                "Current Railway price is still used by another active or trialing subscription",
+            )
     return 0
 
 
@@ -449,7 +554,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     event_parser = subparsers.add_parser("validate-event")
     event_parser.add_argument("--event-json", required=True)
+    event_parser.add_argument("--context-json")
     event_parser.set_defaults(func=command_validate_event)
+
+    overwrite_parser = subparsers.add_parser("validate-overwrite")
+    overwrite_parser.add_argument("--context-json", required=True)
+    overwrite_parser.add_argument("--subscriptions-json", action="append", required=True)
+    overwrite_parser.set_defaults(func=command_validate_overwrite)
 
     endpoint_parser = subparsers.add_parser("select-endpoint")
     endpoint_parser.add_argument("--endpoints-json", required=True)

--- a/backend/tests/test_stripe_entitlement_repair.py
+++ b/backend/tests/test_stripe_entitlement_repair.py
@@ -1,0 +1,130 @@
+import pytest
+
+from backend.scripts import stripe_entitlement_repair as repair
+
+
+def test_live_stripe_key_rejected():
+    with pytest.raises(repair.RepairError) as error:
+        repair.validate_stripe_key("sk" + "_live_" + "EXAMPLE")
+
+    assert error.value.code == "live_stripe_key"
+
+
+def test_missing_stripe_key_rejected():
+    with pytest.raises(repair.RepairError) as error:
+        repair.validate_stripe_key("")
+
+    assert error.value.code == "missing_stripe_key"
+
+
+def test_starter_maps_to_stripe_price_pro_and_pro():
+    mapping = repair.plan_mapping("starter")
+
+    assert mapping.railway_price_variable == "STRIPE_PRICE_PRO"
+    assert mapping.backend_plan == "pro"
+
+
+def test_investor_pro_maps_to_stripe_price_investor_and_investor():
+    mapping = repair.plan_mapping("investor_pro")
+
+    assert mapping.railway_price_variable == "STRIPE_PRICE_INVESTOR"
+    assert mapping.backend_plan == "investor"
+
+
+def test_multiple_subscriptions_produce_warning_with_deterministic_choice():
+    selected, warning = repair.select_subscription(
+        {
+            "data": [
+                {
+                    "id": "SUBSCRIPTION_OLD",
+                    "status": "active",
+                    "created": 10,
+                    "items": {"data": []},
+                },
+                {
+                    "id": "SUBSCRIPTION_NEW",
+                    "status": "trialing",
+                    "created": 20,
+                    "items": {"data": []},
+                },
+            ]
+        }
+    )
+
+    assert selected["id"] == "SUBSCRIPTION_NEW"
+    assert warning is True
+
+
+@pytest.mark.parametrize("status", ["canceled", "incomplete"])
+def test_canceled_or_incomplete_subscription_cannot_be_applied(status):
+    assert repair.can_apply_subscription(status) is False
+
+
+def test_dry_run_match_detection_performs_no_write():
+    result = repair.railway_match_result(
+        {"STRIPE_PRICE_PRO": "PRICE_IDENTIFIER"}, "STRIPE_PRICE_PRO", "PRICE_IDENTIFIER"
+    )
+
+    assert result == "MATCH"
+
+
+def test_missing_event_id_skips_resend():
+    assert repair.main(["validate-event-id", "--event-id", ""]) == 0
+
+
+def test_malformed_event_id_is_rejected():
+    with pytest.raises(repair.RepairError) as error:
+        repair.validate_event_id("EVENT_IDENTIFIER")
+
+    assert error.value.code == "malformed_event_id"
+
+
+def test_live_mode_event_is_rejected():
+    with pytest.raises(repair.RepairError) as error:
+        repair.validate_event({"livemode": True, "type": "checkout.session.completed"})
+
+    assert error.value.code == "event_not_test_mode"
+
+
+def test_unknown_event_type_is_rejected():
+    with pytest.raises(repair.RepairError) as error:
+        repair.validate_event({"livemode": False, "type": "payment_intent.succeeded"})
+
+    assert error.value.code == "unknown_event_type"
+
+
+def test_output_redaction_does_not_expose_full_ids():
+    full_identifier = "IDENTIFIER_COMPLETE_VALUE"
+    redacted = repair.redact_identifier(full_identifier)
+
+    assert full_identifier not in redacted
+    assert redacted == "IDENTIFIER_...[redacted]"
+
+
+def test_price_validation_requires_test_mode_expected_product_and_recurring():
+    repair.validate_price(
+        {
+            "id": "PRICE_IDENTIFIER",
+            "livemode": False,
+            "active": True,
+            "recurring": {"interval": "month"},
+            "product": "PRODUCT_IDENTIFIER",
+        },
+        "PRODUCT_IDENTIFIER",
+    )
+
+
+def test_price_validation_rejects_unexpected_product():
+    with pytest.raises(repair.RepairError) as error:
+        repair.validate_price(
+            {
+                "id": "PRICE_IDENTIFIER",
+                "livemode": False,
+                "active": True,
+                "recurring": {"interval": "month"},
+                "product": "PRODUCT_A",
+            },
+            "PRODUCT_B",
+        )
+
+    assert error.value.code == "unexpected_product"

--- a/backend/tests/test_stripe_entitlement_repair.py
+++ b/backend/tests/test_stripe_entitlement_repair.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from backend.scripts import stripe_entitlement_repair as repair
@@ -128,3 +130,214 @@ def test_price_validation_rejects_unexpected_product():
         )
 
     assert error.value.code == "unexpected_product"
+
+
+def test_old_price_with_other_eligible_subscriber_blocks_overwrite():
+    assert repair.has_other_eligible_subscribers(
+        {
+            "data": [
+                {
+                    "id": "SELECTED_SUBSCRIPTION",
+                    "status": "active",
+                    "items": {
+                        "data": [
+                            {
+                                "price": {
+                                    "id": "NEW_PRICE_IDENTIFIER",
+                                    "recurring": {"interval": "month"},
+                                }
+                            }
+                        ]
+                    },
+                },
+                {
+                    "id": "OTHER_SUBSCRIPTION",
+                    "status": "trialing",
+                    "items": {
+                        "data": [
+                            {
+                                "price": {
+                                    "id": "OLD_PRICE_IDENTIFIER",
+                                    "recurring": {"interval": "month"},
+                                }
+                            }
+                        ]
+                    },
+                },
+            ]
+        },
+        selected_subscription_id="SELECTED_SUBSCRIPTION",
+        old_price_id="OLD_PRICE_IDENTIFIER",
+    )
+
+
+def test_old_price_without_other_eligible_subscriber_allows_overwrite():
+    assert not repair.has_other_eligible_subscribers(
+        {
+            "data": [
+                {
+                    "id": "OTHER_SUBSCRIPTION",
+                    "status": "canceled",
+                    "items": {
+                        "data": [
+                            {
+                                "price": {
+                                    "id": "OLD_PRICE_IDENTIFIER",
+                                    "recurring": {"interval": "month"},
+                                }
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        selected_subscription_id="SELECTED_SUBSCRIPTION",
+        old_price_id="OLD_PRICE_IDENTIFIER",
+    )
+
+
+def test_checkout_event_must_match_selected_customer_and_subscription():
+    repair.validate_event_binding(
+        {
+            "livemode": False,
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "customer": "CUSTOMER_IDENTIFIER",
+                    "subscription": "SELECTED_SUBSCRIPTION",
+                }
+            },
+        },
+        {
+            "customer_id": "CUSTOMER_IDENTIFIER",
+            "subscription_id": "SELECTED_SUBSCRIPTION",
+        },
+    )
+
+
+def test_subscription_event_must_match_selected_subscription():
+    with pytest.raises(repair.RepairError) as error:
+        repair.validate_event_binding(
+            {
+                "livemode": False,
+                "type": "customer.subscription.deleted",
+                "data": {
+                    "object": {
+                        "id": "OTHER_SUBSCRIPTION",
+                        "customer": "CUSTOMER_IDENTIFIER",
+                    }
+                },
+            },
+            {
+                "customer_id": "CUSTOMER_IDENTIFIER",
+                "subscription_id": "SELECTED_SUBSCRIPTION",
+            },
+        )
+
+    assert error.value.code == "event_subscription_mismatch"
+
+
+def test_event_customer_mismatch_is_rejected():
+    with pytest.raises(repair.RepairError) as error:
+        repair.validate_event_binding(
+            {
+                "livemode": False,
+                "type": "customer.subscription.updated",
+                "data": {
+                    "object": {
+                        "id": "SELECTED_SUBSCRIPTION",
+                        "customer": "OTHER_CUSTOMER",
+                    }
+                },
+            },
+            {
+                "customer_id": "CUSTOMER_IDENTIFIER",
+                "subscription_id": "SELECTED_SUBSCRIPTION",
+            },
+        )
+
+    assert error.value.code == "event_customer_mismatch"
+
+
+def test_validate_overwrite_command_checks_all_subscription_inventories(tmp_path):
+    context_json = tmp_path / "context.json"
+    selected_json = tmp_path / "selected.json"
+    global_json = tmp_path / "global.json"
+    context_json.write_text(
+        json.dumps(
+            {
+                "subscription_id": "SELECTED_SUBSCRIPTION",
+                "current_railway_price_id": "OLD_PRICE_IDENTIFIER",
+                "price_id": "NEW_PRICE_IDENTIFIER",
+            }
+        ),
+        encoding="utf-8",
+    )
+    selected_json.write_text(json.dumps({"data": []}), encoding="utf-8")
+    global_json.write_text(
+        json.dumps(
+            {
+                "data": [
+                    {
+                        "id": "OTHER_SUBSCRIPTION",
+                        "status": "active",
+                        "items": {
+                            "data": [
+                                {
+                                    "price": {
+                                        "id": "OLD_PRICE_IDENTIFIER",
+                                        "recurring": {"interval": "month"},
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        repair.main(
+            [
+                "validate-overwrite",
+                "--context-json",
+                str(context_json),
+                "--subscriptions-json",
+                str(selected_json),
+                "--subscriptions-json",
+                str(global_json),
+            ]
+        )
+        == 2
+    )
+
+
+def test_validate_overwrite_rejects_truncated_old_price_inventory(tmp_path):
+    context_json = tmp_path / "context.json"
+    subscriptions_json = tmp_path / "subscriptions.json"
+    context_json.write_text(
+        json.dumps(
+            {
+                "subscription_id": "SELECTED_SUBSCRIPTION",
+                "current_railway_price_id": "OLD_PRICE_IDENTIFIER",
+                "price_id": "NEW_PRICE_IDENTIFIER",
+            }
+        ),
+        encoding="utf-8",
+    )
+    subscriptions_json.write_text(json.dumps({"data": [], "has_more": True}), encoding="utf-8")
+
+    assert (
+        repair.main(
+            [
+                "validate-overwrite",
+                "--context-json",
+                str(context_json),
+                "--subscriptions-json",
+                str(subscriptions_json),
+            ]
+        )
+        == 2
+    )


### PR DESCRIPTION
## Summary
Adds a secure, manually dispatched Stripe entitlement repair workflow for the current production test-mode issue where Stripe webhook delivery reaches backend logic but returns `unknown_price_id` because the Stripe test subscription price does not match the Railway backend price mapping.

## Root cause
The previous StripeObject `.get()` crash is fixed. The remaining failure is an entitlement mapping mismatch: the active/trialing Stripe test subscription for the tested account can contain a recurring Price ID that is not equal to the Railway backend variable used by the webhook mapper. For the Investor Starter case, the backend plan value is `pro`, mapped from `STRIPE_PRICE_PRO`.

## What changed
- Added `.github/workflows/stripe-entitlement-repair.yml`.
- Added `backend/scripts/stripe_entitlement_repair.py` for safe plan mapping, Stripe object selection, price/product validation, Railway comparison, event validation, endpoint selection, and redacted summaries.
- Added `backend/tests/test_stripe_entitlement_repair.py` covering the repair helper guardrails.

## Dry-run behavior
When `apply_changes=false`, the workflow discovers the exact normalized Stripe customer, selects the latest eligible active/trialing subscription, extracts its recurring price, validates test mode/product/active/recurring state, compares the discovered price against Railway, and writes only a sanitized job summary.

Dry-run does not:
- modify Railway variables
- redeploy Railway
- resend Stripe events
- print complete customer, subscription, price, event, secret, or password values

## Apply-mode safeguards
When `apply_changes=true`, the workflow:
- requires `STRIPE_TEST_RESTRICTED_KEY` and rejects live-mode Stripe keys
- requires `RAILWAY_TOKEN`
- masks discovered Stripe identifiers with `add-mask`
- uses restrictive temporary files and removes them in an `always()` cleanup step
- updates only the mapped Railway price variable
- gates event resend on a successful production backend `/health` check
- rejects malformed event IDs, live-mode events, and unsupported event types
- uses `stripe events resend`, not `stripe trigger`

The exact incident variable that would be updated for `expected_plan=starter` is `STRIPE_PRICE_PRO`. For `expected_plan=investor_pro`, the workflow maps to `STRIPE_PRICE_INVESTOR`.

## Required secrets
- `STRIPE_TEST_RESTRICTED_KEY`
- `RAILWAY_TOKEN`

The post-repair verification path can dispatch the existing authenticated production smoke workflow only when the relevant E2E credential secrets are available to that workflow. Otherwise it reports that final account verification remains manual.

## Runtime status from this PR authoring session
- Duplicate subscriptions found: not checked here; the workflow reports this at dispatch time without cancelling duplicates.
- Event resent: no. Apply mode was not run from this local session.
- Live Stripe data touched: no.
- Railway production variables changed: no.

## Validation
- `python -m pytest backend/tests/test_stripe_entitlement_repair.py -q` passed: 15 tests.
- `python -m pytest backend/tests/test_stripe_webhook.py backend/tests/test_stripe_trial.py backend/tests/test_stripe_webhook_monitoring.py -q` passed: 38 tests.
- `python -m pytest backend/tests/ -q` passed.
- `npm --prefix frontend run lint` passed.
- Workflow YAML parse passed.
- `git diff --check` passed.
- Diff security scan was run for `sk_test_`, `sk_live_`, `rk_test_`, `rk_live_`, `price_`, `cus_`, `sub_`, `evt_`, `password`, and `secret`; hits were limited to code/variable names, validation prefixes, or secret references, not committed secret values or complete Stripe IDs.

## Scope guardrails
- No Stripe products, prices, currencies, trials, or pricing were changed.
- No duplicate subscriptions are cancelled.
- No live-mode Stripe data is modified.
- Webhook signature verification is not weakened.
- No return/success-page entitlement grant was added; `users.plan` remains the source of truth.
- No `.env` file was created or committed.
- Sprint 2B and Sprint 3 were untouched.